### PR TITLE
Feature original price

### DIFF
--- a/server/modules/databaseClient/storeTrade.js
+++ b/server/modules/databaseClient/storeTrade.js
@@ -1,12 +1,12 @@
 const pool = require('../pool');
 
-const storeTrade = (newOrder) => {
+const storeTrade = (newOrder, originalDetails) => {
   return new Promise((resolve, reject) => {
     // add new order to the database
     const sqlText = `INSERT INTO "orders" 
     ("id", "price", "size", "side", "settled", "product_id", "time_in_force", 
-    "created_at", "done_at", "fill_fees", "filled_size", "executed_value") 
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);`;
+    "created_at", "done_at", "fill_fees", "filled_size", "executed_value", "original_buy_price", "original_sell_price") 
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);`;
     pool.query(sqlText, [
       newOrder.id,
       newOrder.price,
@@ -19,9 +19,9 @@ const storeTrade = (newOrder) => {
       newOrder.done_at,
       newOrder.fill_fees,
       newOrder.filled_size,
-      newOrder.executed_value
-      // newOrder.original_buy_price
-      // newOrder.original_sell_price
+      newOrder.executed_value,
+      originalDetails.original_buy_price,
+      originalDetails.original_sell_price
     ])
       .then((results) => {
         const success = {

--- a/server/modules/robot/exchange.js
+++ b/server/modules/robot/exchange.js
@@ -20,7 +20,7 @@ const exchange = async (ordersToCheck) => {
           console.log('at the exchange with trade ID:', dbOrder.id);
           // send request to coinbase API to get status of a trade
           return authedClient.getOrder(dbOrder.id)
-            // now can refer to dbOrder as old status of trade and cbOrder as current status
+            // ----- now can refer to dbOrder as old status of trade and cbOrder as current status
             .then((cbOrder) => {
               // if it has indeed settled, make the opposit trade and call it good
               if (cbOrder.settled) {
@@ -32,7 +32,7 @@ const exchange = async (ordersToCheck) => {
                 return authedClient.placeOrder(tradeDetails)
                   .then(pendingTrade => {
                     // after trade is placed, store the returned pending trade values in the database
-                    databaseClient.storeTrade(pendingTrade)
+                    databaseClient.storeTrade(pendingTrade, dbOrder)
                       .then(() => {
                         // after order succeeds, update settled in DB to be TRUE and add settlement info
                         const queryText = `UPDATE "orders" SET "settled" = NOT "settled", "done_at" = $1, "fill_fees" = $2,

--- a/server/modules/robot/flipTrade.js
+++ b/server/modules/robot/flipTrade.js
@@ -17,12 +17,12 @@ const flipTrade = (dbOrder, cbOrder) => {
     if (cbOrder.side === "buy") {
       // if it was a buy, sell for more. multiply old price
       tradeDetails.side = "sell"
-      tradeDetails.price = ((Math.round((dbOrder.price * 1.03) * 100)) / 100);
+      tradeDetails.price = dbOrder.original_sell_price;
       console.log('selling');
     } else {
       // if it was a sell, buy for less. divide old price
       tradeDetails.side = "buy"
-      tradeDetails.price = ((Math.round((dbOrder.price / 1.03) * 100)) / 100);
+      tradeDetails.price = original_buy_price;
       console.log('buying');
     }
     // return the tradeDetails object

--- a/server/routes/trade.router.js
+++ b/server/routes/trade.router.js
@@ -22,11 +22,14 @@ router.post('/order', (req, res) => {
   const order = req.body;
   // tradeDetails const should take in values sent from trade component form
   const tradeDetails = {
-    side: 'buy',
+    // original_sell_price: order.original_sell_price,
+    // original_buy_price: order.price,
+    side: order.side,
     price: order.price, // USD
     size: order.size, // BTC
-    product_id: 'BTC-USD',
+    product_id: order.product_id,
   };
+  console.log(tradeDetails);
   // function to send the order with the CB API to CB and place the trade
   authedClient.placeOrder(tradeDetails)
   // after trade is placed, store the returned pending trade values in the database

--- a/server/routes/trade.router.js
+++ b/server/routes/trade.router.js
@@ -33,7 +33,7 @@ router.post('/order', (req, res) => {
   // function to send the order with the CB API to CB and place the trade
   authedClient.placeOrder(tradeDetails)
   // after trade is placed, store the returned pending trade values in the database
-    .then(pendingTrade => databaseClient.storeTrade(pendingTrade, tradeDetails))
+    .then(pendingTrade => databaseClient.storeTrade(pendingTrade, order))
     .then(results => {
       console.log(`order placed, given to db with reply:`, results.message);
       if (results.success) {

--- a/server/routes/trade.router.js
+++ b/server/routes/trade.router.js
@@ -33,7 +33,7 @@ router.post('/order', (req, res) => {
   // function to send the order with the CB API to CB and place the trade
   authedClient.placeOrder(tradeDetails)
   // after trade is placed, store the returned pending trade values in the database
-    .then(pendingTrade => databaseClient.storeTrade(pendingTrade))
+    .then(pendingTrade => databaseClient.storeTrade(pendingTrade, tradeDetails))
     .then(results => {
       console.log(`order placed, given to db with reply:`, results.message);
       if (results.success) {
@@ -44,11 +44,14 @@ router.post('/order', (req, res) => {
     })
     // .then(result => {console.log('just got back from storing this in db:', result)})
     .catch((error) => {
-      if (error.data.message === 'Insufficient funds') {
+      if (error.data.message !== undefined && error.data.message === 'Insufficient funds') {
         console.log('no money');
         res.sendStatus(400);
+        console.log('new order process failed', error.data.message);
+      } else {
+        console.log('new order process failed', error);
+        res.sendStatus(500)
       }
-      console.log('new order process failed', error.data.message);
     });
 });
 

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -3,11 +3,12 @@
 body {
   background-color: #c7c7b1;
   font-family     : 'Syne Mono', monospace;
+
 }
 
 /* === BOXES === */
 .boxed {
-  margin: .2rem;
+  /* margin: .2rem; */
   border: 1px solid black;
   /* width: fit-content; */
 }

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -5,6 +5,13 @@ body {
   font-family     : 'Syne Mono', monospace;
 }
 
+/* === BOXES === */
+.boxed {
+  margin: .2rem;
+  border: 1px solid black;
+  /* width: fit-content; */
+}
+
 /* === BUTTONS === */
 
 .btn-red {

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -10,7 +10,17 @@ body {
 .boxed {
   /* margin: .2rem; */
   border: 1px solid black;
+  height: fit-content;
   /* width: fit-content; */
+}
+
+.tall {
+  height: 100%;
+}
+
+.dark {
+  background-color: darkgrey;
+  border: none;
 }
 
 /* === BUTTONS === */

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -1,3 +1,63 @@
+@import url('https://fonts.googleapis.com/css2?family=Syne+Mono&display=swap');
+
 body {
-  background-color     : rgb(172, 171, 133);
+  background-color: #c7c7b1;
+  font-family     : 'Syne Mono', monospace;
+}
+
+/* === BUTTONS === */
+
+.btn-red {
+  background-color: rgb(236, 65, 65);
+  font-family     : inherit;
+  box-shadow      : inset 2px 2px rgba(255, 255, 255, .6), inset -2px -2px rgba(0, 0, 0, .6);
+}
+
+.btn-red:hover {
+  background-color: lightcoral;
+}
+
+.btn-red:focus {
+  /* remove annoying rounded blue outline when button is focused */
+  outline         : none;
+  /* change color when focused to resolve accesibility concerns */
+  background-color: rgba(184, 113, 140, 0.507);
+}
+
+.btn-green {
+  background-color: rgb(109, 145, 108);
+  font-family     : inherit;
+  box-shadow      : inset 2px 2px rgba(255, 255, 255, .6), inset -2px -2px rgba(0, 0, 0, .6);
+}
+
+.btn-green:hover {
+  background-color: rgb(156, 180, 155);
+}
+
+.btn-green:focus {
+  /* remove annoying rounded blue outline when button is focused */
+  outline         : none;
+  /* change color when focused to resolve accesibility concerns */
+  background-color: rgba(128, 177, 159, 0.596);
+}
+
+.btn-blue {
+  background-color: rgb(108, 123, 145);
+  font-family     : inherit;
+  box-shadow      : inset 2px 2px rgba(255, 255, 255, .6), inset -2px -2px rgba(0, 0, 0, .6);
+}
+
+.btn-blue:hover {
+  background-color: rgb(155, 160, 180);
+}
+
+.btn-blue:focus {
+  /* remove annoying rounded blue outline when button is focused */
+  outline         : none;
+  /* change color when focused to resolve accesibility concerns */
+  background-color: rgba(119, 115, 179, 0.596);
+}
+
+button:active {
+  box-shadow: inset -2px -2px rgba(255, 255, 255, .6), inset 2px 2px rgba(0, 0, 0, .6);
 }

--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -9,9 +9,7 @@
 .header {
     grid-column-start  : 1;
     grid-column-end    : 4;
-    background-color   : #2d996c;
-    /* display         : flex; */
-    /* flex-direction  : column; */
+    background-color: rgb(98, 127, 128);
     text-align         : center;
     align-items        : center;
     font-size          : calc(9px + 2vmin);

--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -3,12 +3,13 @@
     /* this is STRICTLY A BUSINESS ROBOT, and the color should reflect that! */
     grid-template-columns: 0fr min-content 4fr min-content 0fr;
     gap                  : .4rem;
-    grid-template-rows   : calc((9px + 2vmin)*4.3) auto auto min-content 0fr;
+    grid-template-rows   : calc((9px + 2vmin)*4.3) max-content auto min-content 0fr;
     height               : 100vh;
 }
 
 .header {
     grid-column     : 1/6;
+    grid-row        : 1;
     background-color: #000000;
     text-align      : center;
     align-items     : center;

--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -9,7 +9,7 @@
 .header {
     grid-column-start  : 1;
     grid-column-end    : 4;
-    background-color: rgb(98, 127, 128);
+    background-color: #000000;
     text-align         : center;
     align-items        : center;
     font-size          : calc(9px + 2vmin);

--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -1,17 +1,17 @@
 .Home {
     display              : grid;
     /* this is STRICTLY A BUSINESS ROBOT, and the color should reflect that! */
-    grid-template-columns: 1fr 4fr 1fr;
-    grid-template-rows   : calc((9px + 2vmin)*4.3) auto auto 10rem;
-    height: 100vh;
+    grid-template-columns: 0fr min-content 4fr min-content 0fr;
+    gap                  : .4rem;
+    grid-template-rows   : calc((9px + 2vmin)*4.3) auto auto min-content 0fr;
+    height               : 100vh;
 }
 
 .header {
-    grid-column-start  : 1;
-    grid-column-end    : 4;
+    grid-column     : 1/6;
     background-color: #000000;
-    text-align         : center;
-    align-items        : center;
-    font-size          : calc(9px + 2vmin);
-    color              : white;
+    text-align      : center;
+    align-items     : center;
+    font-size       : calc(9px + 2vmin);
+    color           : white;
 }

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -7,6 +7,7 @@ import React, {
 import Trade from '../Trade/Trade.js';
 import Updates from '../Updates/Updates.js';
 import ToggleBot from '../ToggleBot/ToggleBot'
+import TradeList from '../TradeList/TradeList'
 import './Home.css'
 // import mapStoreToProps from '../../redux/mapStoreToProps';
 
@@ -24,7 +25,7 @@ function Home(props) {
       <ToggleBot />
       <Trade />
       {/* TODO - display all orders from database in two categories "buy" & "sell" */}
-      <p className="TradeList">LIST OF TRADES GOES HERE</p>
+      <TradeList />
       <Updates />
     </div>
   );

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -8,6 +8,7 @@ import Trade from '../Trade/Trade.js';
 import Updates from '../Updates/Updates.js';
 import ToggleBot from '../ToggleBot/ToggleBot'
 import TradeList from '../TradeList/TradeList'
+import Status from '../Status/Status'
 import './Home.css'
 // import mapStoreToProps from '../../redux/mapStoreToProps';
 
@@ -27,6 +28,7 @@ function Home(props) {
       {/* TODO - display all orders from database in two categories "buy" & "sell" */}
       <TradeList />
       <Updates />
+      <Status />
     </div>
   );
 }

--- a/src/components/SingleTrade/SingleTrade.css
+++ b/src/components/SingleTrade/SingleTrade.css
@@ -1,0 +1,25 @@
+.SingleTrade {
+    text-align: center;
+    border-bottom: black 1px solid;
+    height: fit-content;
+    background-color: rgb(125, 209, 132);
+}
+.SingleTrade:nth-child(2n) {
+    background-color: rgb(96, 173, 103);
+}
+.SingleTrade:nth-child(8n) {
+    background-color: rgb(167, 119, 92);
+}
+
+.SingleTrade:nth-child(9n) {
+    background-color: rgb(199, 144, 112);
+}
+
+.SingleTrade:nth-child(10n) {
+    background-color: rgb(167, 119, 92);
+}
+
+.SingleTrade p{
+    margin: auto;
+    padding: 1rem;
+}

--- a/src/components/SingleTrade/SingleTrade.css
+++ b/src/components/SingleTrade/SingleTrade.css
@@ -7,23 +7,25 @@
 .SingleTrade:nth-child(2n) {
     background-color: rgb(96, 173, 103);
 }
-.SingleTrade:nth-child(8n) {
-    background-color: rgb(167, 119, 92);
-}
 
 .SingleTrade:nth-child(9n) {
-    background-color: rgb(199, 144, 112);
+    background-color: rgb(167, 119, 92);
+    border-top: solid 1px black;
 }
 
 .SingleTrade:nth-child(10n) {
-    background-color: rgb(167, 119, 92);
-}
-
-.SingleTrade:nth-child(11n) {
     background-color: rgb(199, 144, 112);
 }
 
+.SingleTrade:nth-child(11n) {
+    background-color: rgb(167, 119, 92);
+}
+
 .SingleTrade:nth-child(12n) {
+    background-color: rgb(199, 144, 112);
+}
+
+.SingleTrade:nth-child(13n) {
     background-color: rgb(167, 119, 92);
 }
 

--- a/src/components/SingleTrade/SingleTrade.css
+++ b/src/components/SingleTrade/SingleTrade.css
@@ -19,6 +19,18 @@
     background-color: rgb(167, 119, 92);
 }
 
+.SingleTrade:nth-child(11n) {
+    background-color: rgb(199, 144, 112);
+}
+
+.SingleTrade:nth-child(12n) {
+    background-color: rgb(167, 119, 92);
+}
+
+.SingleTrade:last-child {
+    border: none;
+}
+
 .SingleTrade p{
     margin: auto;
     padding: 1rem;

--- a/src/components/SingleTrade/SingleTrade.js
+++ b/src/components/SingleTrade/SingleTrade.js
@@ -1,0 +1,15 @@
+import React, { useState } from 'react';
+import { connect, useDispatch } from 'react-redux';
+import './SingleTrade.css'
+
+function SingleTrade() {
+  const dispatch = useDispatch();
+
+  return (
+    <div className="SingleTrade">
+      <p className="trade">~~~~~~~~~~ LIST OF TRADES GOES HERE ~~~~~~~~~~</p>
+    </div>
+  )
+}
+
+export default SingleTrade;

--- a/src/components/Status/Status.css
+++ b/src/components/Status/Status.css
@@ -1,0 +1,4 @@
+.Status {
+    grid-column: 4;
+    grid-row: 3;
+}

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import { connect, useDispatch } from 'react-redux';
+import './Status.css'
+
+function Status() {
+  const dispatch = useDispatch();
+
+  return (
+    <div className="Status boxed">
+        <h3 className="title">
+        Status
+        </h3>
+      <p className="info">status feature coming</p>
+    </div>
+  )
+}
+
+export default Status;

--- a/src/components/ToggleBot/ToggleBot.css
+++ b/src/components/ToggleBot/ToggleBot.css
@@ -1,5 +1,6 @@
 .ToggleBot {
     grid-column-start: 3;
+    margin: .2rem;
 }
 
 .toggle {

--- a/src/components/ToggleBot/ToggleBot.css
+++ b/src/components/ToggleBot/ToggleBot.css
@@ -3,8 +3,8 @@
 }
 
 .toggle {
-    background-color: hotpink;
-    width: 100%;
+    background-color: #cc6699;
+    width: 10rem;
     height: 10rem;
     font-size: xx-large;
 }

--- a/src/components/ToggleBot/ToggleBot.css
+++ b/src/components/ToggleBot/ToggleBot.css
@@ -1,10 +1,10 @@
 .ToggleBot {
-    grid-column-start: 3;
+    grid-column-start: 4;
     margin: .2rem;
 }
 
 .toggle {
-    background-color: #cc6699;
+    background-color: #b34053;
     width: 10rem;
     height: 10rem;
     font-size: xx-large;

--- a/src/components/ToggleBot/ToggleBot.css
+++ b/src/components/ToggleBot/ToggleBot.css
@@ -1,6 +1,8 @@
 .ToggleBot {
-    grid-column-start: 4;
-    margin: .2rem;
+    grid-column: 4;
+    grid-row: 2;
+    /* margin: .2rem; */
+    height: 10rem;
 }
 
 .toggle {
@@ -8,9 +10,4 @@
     width: 10rem;
     height: 10rem;
     font-size: xx-large;
-}
-
-.TradeList {
-    grid-column: 2;
-    grid-row: 3;
 }

--- a/src/components/ToggleBot/ToggleBot.js
+++ b/src/components/ToggleBot/ToggleBot.js
@@ -8,7 +8,7 @@ function ToggleBot() {
   return (
     <div className="ToggleBot">
       <button
-        className="toggle"
+        className="toggle btn-blue"
         onClick={() => dispatch({ type: 'TOGGLE_BOT' })}>
         TOGGLE BOT
     </button>

--- a/src/components/Trade/Trade.css
+++ b/src/components/Trade/Trade.css
@@ -67,7 +67,7 @@ input {
 }
 
 .btn-send-trade {
-    /* float: right; */
-    /* background-color: rgb(93, 216, 238); */
-    font-size: large;
+    height: 3rem;
+    margin: 1rem auto;
+    font-size: larger;
 }

--- a/src/components/Trade/Trade.css
+++ b/src/components/Trade/Trade.css
@@ -21,6 +21,10 @@
     margin     : .4rem;
 }
 
+.small {
+    font-size: small;
+}
+
 /* === FORM === */
 
 .new-trade-form {

--- a/src/components/Trade/Trade.css
+++ b/src/components/Trade/Trade.css
@@ -6,9 +6,8 @@
     grid-row             : 2/4;
     grid-template-columns: auto auto;
     grid-template-rows   : auto auto;
-    height               : min-content;
-    margin: 1rem;
-    border: 1px solid black;
+    /* height               : min-content; */
+
 }
 
 .title {

--- a/src/components/Trade/Trade.css
+++ b/src/components/Trade/Trade.css
@@ -1,7 +1,7 @@
 .Trade {
     display              : grid;
-    grid-column-start    : 2;
-    grid-row             : 2;
+    grid-column-start    : 1;
+    grid-row             : 2/4;
     grid-template-columns: auto auto;
     grid-template-rows   : auto auto;
     height               : min-content;

--- a/src/components/Trade/Trade.css
+++ b/src/components/Trade/Trade.css
@@ -2,23 +2,23 @@
 
 .Trade {
     display              : grid;
-    grid-column-start    : 1;
+    grid-column          : 2;
     grid-row             : 2/4;
     grid-template-columns: auto auto;
     grid-template-rows   : auto auto;
-    /* height               : min-content; */
+    height               : min-content;
 
 }
 
 .title {
-    grid-row   : 1;
-    grid-column: 1 / 3;
+    grid-row        : 1;
+    grid-column     : 1 / 3;
     background-color: rgb(98, 127, 128);
-    /* margin     : .4rem auto; */
-    margin-top: 0;
-    text-align: center;
-    /* border-top: 1px solid black; */
-    border-bottom: 1px solid black;
+    /* margin       : .4rem auto; */
+    margin          : 0;
+    text-align      : center;
+    /* border-top   : 1px solid black; */
+    border-bottom   : 1px solid black;
 }
 
 .trade-description {

--- a/src/components/Trade/Trade.css
+++ b/src/components/Trade/Trade.css
@@ -4,42 +4,32 @@
     display              : grid;
     grid-column          : 2;
     grid-row             : 2/4;
-    grid-template-columns: auto auto;
-    grid-template-rows   : auto auto;
+    /* grid-template-columns: auto auto;
+    grid-template-rows   : auto auto; */
     height               : min-content;
 
 }
 
 .title {
-    grid-row        : 1;
-    grid-column     : 1 / 3;
     background-color: rgb(98, 127, 128);
-    /* margin       : .4rem auto; */
     margin          : 0;
     text-align      : center;
-    /* border-top   : 1px solid black; */
     border-bottom   : 1px solid black;
 }
 
-.trade-description {
-    grid-column: 2;
-    grid-row   : 2;
-    margin     : 0 1rem;
+.info {
+    margin     : .4rem;
 }
 
 /* === FORM === */
 
 .new-trade-form {
-    grid-column       : 1;
-    grid-row          : 2;
     display           : flex;
-    /* justify-content: right; */
     flex-direction    : column;
+    margin     : .4rem;
+
 }
 
-label {
-    /* width: max-content; */
-}
 
 /* === INPUTS === */
 
@@ -56,13 +46,14 @@ input {
     /* margin: .4rem 0 .4rem auto; */
     display         : flex;
     flex-direction  : column;
-    /* justify-items: right; */
+    margin     : .4rem auto;
+
 }
 
 /* === BUTTONS === */
 
 .increment-buttons {
-    margin: auto;
+    margin: .1rem auto;
     width : max-content;
 }
 

--- a/src/components/Trade/Trade.css
+++ b/src/components/Trade/Trade.css
@@ -1,3 +1,5 @@
+/* === MAIN === */
+
 .Trade {
     display              : grid;
     grid-column-start    : 1;
@@ -5,22 +7,19 @@
     grid-template-columns: auto auto;
     grid-template-rows   : auto auto;
     height               : min-content;
+    margin: 1rem;
+    border: 1px solid black;
 }
 
-.decrease input {
-    background-color: red;
-    width           : 4rem;
-    /* margin       : auto; */
-    /* margin-right : 0; */
-}
-
-/* .decrease {
-    margin: 0;
-} */
-
-.increase input {
-    background-color: rgb(20, 238, 20);
-    width           : 4rem;
+.title {
+    grid-row   : 1;
+    grid-column: 1 / 3;
+    background-color: rgb(98, 127, 128);
+    /* margin     : .4rem auto; */
+    margin-top: 0;
+    text-align: center;
+    /* border-top: 1px solid black; */
+    border-bottom: 1px solid black;
 }
 
 .trade-description {
@@ -29,38 +28,56 @@
     margin     : 0 1rem;
 }
 
+/* === FORM === */
+
 .new-trade-form {
-    grid-column: 1;
-    grid-row   : 2;
-    display: flex;
+    grid-column       : 1;
+    grid-row          : 2;
+    display           : flex;
     /* justify-content: right; */
-    flex-direction: column;
-}
-
-.title {
-    grid-row   : 1;
-    grid-column: 1 / 3;
-    margin     : 1rem auto;
-}
-
-.increment-buttons {
-    margin: auto 0 auto auto;
-    width : max-content;
-}
-
-.btn-send-trade {
-    float: right;
-    background-color: rgb(93, 216, 238);
-    font-size: large;
-}
-
-.number-inputs {
-    margin: .4rem 0 .4rem auto;
-    display: flex;
-    flex-direction: column;
-    justify-items: right;
+    flex-direction    : column;
 }
 
 label {
-    width: max-content;
+    /* width: max-content; */
+}
+
+/* === INPUTS === */
+
+input {
+    background      : rgb(209, 202, 192);
+    /* color        : rgb(209, 202, 192); */
+    background-color: rgb(209, 202, 192);
+    font-family     : inherit;
+    /* width        : 100%; */
+    /* margin       : 0% .2%; */
+}
+
+.number-inputs {
+    /* margin: .4rem 0 .4rem auto; */
+    display         : flex;
+    flex-direction  : column;
+    /* justify-items: right; */
+}
+
+/* === BUTTONS === */
+
+.increment-buttons {
+    margin: auto;
+    width : max-content;
+}
+
+.increase input {
+    /* background-color: rgb(20, 238, 20); */
+    width: 4rem;
+}
+
+.decrease input {
+    width: 4rem;
+}
+
+.btn-send-trade {
+    /* float: right; */
+    /* background-color: rgb(93, 216, 238); */
+    font-size: large;
 }

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -17,7 +17,7 @@ function Trade(props) {
   // of bitcoin, rounded to the closest $100
   const [transactionSide, setTransactionSide] = useState('buy');
   const [transactionPrice, setTransactionPrice] = useState(30000);
-  const [flippedPrice, setFlippedPrice] = useState(30000);
+  // const [flippedPrice, setFlippedPrice] = useState(30000);
   const [transactionAmount, setTransactionAmount] = useState(0.001);
   const [transactionProduct, setTransactionProduct] = useState('BTC_USD');
   const [TradePairRatio, setTradePairRatio] = useState(1.1);
@@ -25,11 +25,15 @@ function Trade(props) {
 
   function submitTransaction(event) {
     event.preventDefault();
+    // calculate flipped price
+    let original_sell_price = (Math.round((transactionPrice * (TradePairRatio + 100))) / 100)
     dispatch({
       type: 'START_TRADE', payload: {
+        original_sell_price: original_sell_price,
         side: transactionSide,
         price: transactionPrice,
         size: transactionAmount,
+        transactionProduct: transactionProduct
       }
     })
     console.log(`the price is: $${transactionPrice} per 1 BTC`);
@@ -38,7 +42,7 @@ function Trade(props) {
 
   return (
     <div className="Trade boxed tall" >
-      <h3 className="title">New Trade Position</h3>
+      <h3 className="title">New Trade-Pair</h3>
       {/* <div> */}
       {/* form with a single input. Input takes a price point at which 
           to make a trade */}
@@ -49,16 +53,16 @@ function Trade(props) {
           {/* input for setting the price/BTC per transaction. Can be adjusted in $500 steps, or manually input */}
           <label htmlFor="transaction_price">
             Trade price per 1 BTC (in USD):
-            </label>
-            <input
-              type="number"
-              name="transaction_price"
-              value={Number(transactionPrice)}
-              // todo - this could possibly be changed to 100, or add a selector menu thing to toggle between different amounts
-              step={100}
-              required
-              onChange={(event) => setTransactionPrice(event.target.value)}
-            />
+          </label>
+          <input
+            type="number"
+            name="transaction_price"
+            value={Number(transactionPrice)}
+            // todo - this could possibly be changed to 100, or add a selector menu thing to toggle between different amounts
+            step={100}
+            required
+            onChange={(event) => setTransactionPrice(event.target.value)}
+          />
           <div className="increment-buttons">
             <div className="increase">
               <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(transactionPrice + 1000)} value="+1000"></input>
@@ -132,13 +136,20 @@ function Trade(props) {
 
 
         {/* display some details about the new transaction that is going to be made */}
-        <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Send new trade position" />
-      <p className="info">
-        This will tell coinbot to start trading {transactionAmount} BTC
-        between the low purchase price of ${transactionPrice} and
-        the high sell price of ${((Math.round((transactionPrice * 1.03) * 100)) / 100)}.
-        The value in USD for the initial transaction will be about ${((Math.round((transactionPrice * transactionAmount) * 100)) / 100)}.
-      </p>
+        <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Start new trade pair" />
+        <div className="boxed dark">
+          <h4 className="title">New position</h4>
+          <p className="info"><strong>BUY:</strong> ${(transactionPrice * transactionAmount)}</p>
+          <p className="info"><strong>SELL:</strong>${(Math.round((transactionPrice* transactionAmount * (TradePairRatio + 100))) / 100)}</p>
+          <p className="info"><strong>FEE*:</strong> ${(transactionPrice * transactionAmount * .005)}</p>
+          <p className="info">
+            This will tell coinbot to start trading {transactionAmount} BTC
+            between the low purchase price of ${transactionPrice} and
+            the high sell price of ${(Math.round((transactionPrice * (TradePairRatio + 100))) / 100)}.
+            The value in USD for the initial transaction will be about ${((Math.round((transactionPrice * transactionAmount) * 100)) / 100)}.
+          </p>
+          <p className="small">*Fee is estimated and may be different at time of transaction.</p>
+        </div>
       </form>
       {/* </div> */}
     </div>

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -20,7 +20,7 @@ function Trade(props) {
   const [flippedPrice, setFlippedPrice] = useState(30000);
   const [transactionAmount, setTransactionAmount] = useState(0.001);
   const [transactionProduct, setTransactionProduct] = useState('BTC_USD');
-  const [TradePairRatio, setTradePairRatio] = useState('BTC_USD');
+  const [TradePairRatio, setTradePairRatio] = useState(1.1);
   const dispatch = useDispatch();
 
   function submitTransaction(event) {
@@ -43,6 +43,8 @@ function Trade(props) {
       {/* form with a single input. Input takes a price point at which 
           to make a trade */}
       <form className="new-trade-form" onSubmit={submitTransaction} >
+
+
         <div className="number-inputs">
           {/* input for setting the price/BTC per transaction. Can be adjusted in $500 steps, or manually input */}
           <label htmlFor="transaction_price">
@@ -59,17 +61,19 @@ function Trade(props) {
             />
           <div className="increment-buttons">
             <div className="increase">
-              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 1000)} value="+1000"></input>
-              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 100)} value="+100"></input>
-              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 10)} value="+10"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(transactionPrice + 1000)} value="+1000"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(transactionPrice + 100)} value="+100"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(transactionPrice + 10)} value="+10"></input>
             </div>
             <div className="decrease">
-              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 1000)} value="-1000"></input>
-              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 100)} value="-100"></input>
-              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 10)} value="-10"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(transactionPrice - 1000)} value="-1000"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(transactionPrice - 100)} value="-100"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(transactionPrice - 10)} value="-10"></input>
             </div>
           </div>
         </div>
+
+
         <div className="number-inputs">
           {/* input for setting how much bitcoin should be traded per transaction at the specified price */}
           <label htmlFor="transaction_amount">
@@ -85,19 +89,48 @@ function Trade(props) {
           />
           <div className="increment-buttons">
             <div className="increase">
-              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 1000) / 1000)} value="+1"></input>
-              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 100) / 1000)} value="+.100"></input>
-              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 10) / 1000)} value="+.010"></input>
-              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 1) / 1000)} value="+.001"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 1000) / 1000)} value="+1"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 100) / 1000)} value="+.100"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 10) / 1000)} value="+.010"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 1) / 1000)} value="+.001"></input>
             </div>
             <div className="decrease">
-              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 1000) / 1000)} value="-1"></input>
-              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 100) / 1000)} value="-.100"></input>
-              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 10) / 1000)} value="-.010"></input>
-              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 1) / 1000)} value="-.001"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 1000) / 1000)} value="-1"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 100) / 1000)} value="-.100"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 10) / 1000)} value="-.010"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 1) / 1000)} value="-.001"></input>
             </div>
           </div>
         </div>
+
+
+        <div className="number-inputs">
+          {/* input for setting how much bitcoin should be traded per transaction at the specified price */}
+          <label htmlFor="trade-pair-ratio">
+            Trade pair ratio (percent):
+          </label>
+          <input
+            type="number"
+            name="trade-pair-ratio"
+            value={Number(TradePairRatio)}
+            step={0.001}
+            required
+            onChange={(event) => setTradePairRatio(event.target.value)}
+          />
+          <div className="increment-buttons">
+            <div className="increase">
+              <input type="button" className="btn-green" onClick={(event) => setTradePairRatio(Math.round(TradePairRatio * 1000 + 1000) / 1000)} value="+1"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTradePairRatio(Math.round(TradePairRatio * 1000 + 100) / 1000)} value="+0.1"></input>
+
+            </div>
+            <div className="decrease">
+              <input type="button" className="btn-red" onClick={(event) => setTradePairRatio(Math.round(TradePairRatio * 1000 - 1000) / 1000)} value="-1"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTradePairRatio(Math.round(TradePairRatio * 1000 - 100) / 1000)} value="-0.1"></input>
+            </div>
+          </div>
+        </div>
+
+
         {/* display some details about the new transaction that is going to be made */}
       <p className="trade-description">
         This will tell coinbot to start trading {transactionAmount} BTC
@@ -105,7 +138,7 @@ function Trade(props) {
         the high sell price of ${((Math.round((transactionPrice * 1.03) * 100)) / 100)}.
         The value in USD for the initial transaction will be about ${((Math.round((transactionPrice * transactionAmount) * 100)) / 100)}.
       </p>
-        <input className="btn-send-trade" type="submit" name="submit" value="Send new trade position" />
+        <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Send new trade position" />
       </form>
       {/* </div> */}
     </div>

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -37,7 +37,7 @@ function Trade(props) {
   }
 
   return (
-    <div className="Trade" >
+    <div className="Trade boxed" >
       <h3 className="title">New Trade Position</h3>
       {/* <div> */}
       {/* form with a single input. Input takes a price point at which 

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -37,7 +37,7 @@ function Trade(props) {
   }
 
   return (
-    <div className="Trade boxed" >
+    <div className="Trade boxed tall" >
       <h3 className="title">New Trade Position</h3>
       {/* <div> */}
       {/* form with a single input. Input takes a price point at which 
@@ -133,7 +133,7 @@ function Trade(props) {
 
         {/* display some details about the new transaction that is going to be made */}
         <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Send new trade position" />
-      <p className="trade-description">
+      <p className="info">
         This will tell coinbot to start trading {transactionAmount} BTC
         between the low purchase price of ${transactionPrice} and
         the high sell price of ${((Math.round((transactionPrice * 1.03) * 100)) / 100)}.

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -13,30 +13,31 @@ function Trade(props) {
 
   // have this be the default value of whatever 0.001 worth of bitcoin is
   // will need a function to poll the current value every 5 seconds from CB api
-  // todo - default transactionPrice value should automatically start out at the current price
+  // todo - default price value should automatically start out at the current price
   // of bitcoin, rounded to the closest $100
   const [transactionSide, setTransactionSide] = useState('buy');
-  const [transactionPrice, setTransactionPrice] = useState(30000);
+  const [price, setTransactionPrice] = useState(30000);
   // const [flippedPrice, setFlippedPrice] = useState(30000);
   const [transactionAmount, setTransactionAmount] = useState(0.001);
-  const [transactionProduct, setTransactionProduct] = useState('BTC_USD');
+  const [transactionProduct, setTransactionProduct] = useState('BTC-USD');
   const [TradePairRatio, setTradePairRatio] = useState(1.1);
   const dispatch = useDispatch();
 
   function submitTransaction(event) {
     event.preventDefault();
     // calculate flipped price
-    let original_sell_price = (Math.round((transactionPrice * (TradePairRatio + 100))) / 100)
+    let original_sell_price = (Math.round((price * (TradePairRatio + 100))) / 100)
     dispatch({
       type: 'START_TRADE', payload: {
         original_sell_price: original_sell_price,
+        original_buy_price: price,
         side: transactionSide,
-        price: transactionPrice,
+        price: price,
         size: transactionAmount,
-        transactionProduct: transactionProduct
+        product_id: transactionProduct
       }
     })
-    console.log(`the price is: $${transactionPrice} per 1 BTC`);
+    console.log(`the price is: $${price} per 1 BTC`);
     console.log(`the amount is: ${transactionAmount} BTC`);
   }
 
@@ -57,7 +58,7 @@ function Trade(props) {
           <input
             type="number"
             name="transaction_price"
-            value={Number(transactionPrice)}
+            value={Number(price)}
             // todo - this could possibly be changed to 100, or add a selector menu thing to toggle between different amounts
             step={100}
             required
@@ -65,14 +66,14 @@ function Trade(props) {
           />
           <div className="increment-buttons">
             <div className="increase">
-              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(transactionPrice + 1000)} value="+1000"></input>
-              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(transactionPrice + 100)} value="+100"></input>
-              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(transactionPrice + 10)} value="+10"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(price + 1000)} value="+1000"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(price + 100)} value="+100"></input>
+              <input type="button" className="btn-green" onClick={(event) => setTransactionPrice(price + 10)} value="+10"></input>
             </div>
             <div className="decrease">
-              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(transactionPrice - 1000)} value="-1000"></input>
-              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(transactionPrice - 100)} value="-100"></input>
-              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(transactionPrice - 10)} value="-10"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(price - 1000)} value="-1000"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(price - 100)} value="-100"></input>
+              <input type="button" className="btn-red" onClick={(event) => setTransactionPrice(price - 10)} value="-10"></input>
             </div>
           </div>
         </div>
@@ -139,19 +140,19 @@ function Trade(props) {
         <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Start new trade pair" />
         <div className="boxed dark">
           <h4 className="title">New position</h4>
-          <p className="info"><strong>BUY*:</strong> ${(transactionPrice * transactionAmount)}</p>
-          <p className="info"><strong>SELL*:</strong>${(Math.round((transactionPrice* transactionAmount * (TradePairRatio + 100))) / 100)}</p>
+          <p className="info"><strong>BUY*:</strong> ${(price * transactionAmount)}</p>
+          <p className="info"><strong>SELL*:</strong>${(Math.round((price* transactionAmount * (TradePairRatio + 100))) / 100)}</p>
           {/* todo - currently using .005 as the fee multiplier. Should GET account info from coinbase and use that instead */}
-          <p className="info"><strong>FEE*:</strong> ${(transactionPrice * transactionAmount * .005)}</p>
-          <p className="info"><strong>PAIR MARGIN*:</strong> ${(Math.round(( ((transactionPrice* transactionAmount * (TradePairRatio))) - (transactionPrice * transactionAmount) )*100))/100}</p>
+          <p className="info"><strong>FEE*:</strong> ${(price * transactionAmount * .005)}</p>
+          <p className="info"><strong>PAIR MARGIN*:</strong> ${(Math.round(( ((price* transactionAmount * (TradePairRatio))) - (price * transactionAmount) )*100))/100}</p>
           {/* todo - currently using .005 as the fee multiplier. Should GET account info from coinbase and use that instead */}
-          <p className="info"><strong>PAIR PROFIT*:</strong> ${(Math.round(( (Math.round((transactionPrice* transactionAmount * (TradePairRatio + 100))) / 100) - (transactionPrice * transactionAmount)  - (transactionPrice * transactionAmount * .005) * 2)*100))/100}</p>
+          <p className="info"><strong>PAIR PROFIT*:</strong> ${(Math.round(( (Math.round((price* transactionAmount * (TradePairRatio + 100))) / 100) - (price * transactionAmount)  - (price * transactionAmount * .005) * 2)*100))/100}</p>
 
           <p className="info">
             This will tell coinbot to start trading {transactionAmount} BTC
-            between the low purchase price of ${transactionPrice} and
-            the high sell price of ${(Math.round((transactionPrice * (TradePairRatio + 100))) / 100)}.
-            The value in USD for the initial transaction will be about ${((Math.round((transactionPrice * transactionAmount) * 100)) / 100)}.
+            between the low purchase price of ${price} and
+            the high sell price of ${(Math.round((price * (TradePairRatio + 100))) / 100)}.
+            The value in USD for the initial transaction will be about ${((Math.round((price * transactionAmount) * 100)) / 100)}.
           </p>
           <p className="small info">*Costs, fees, margin, and profit, are estimated and may be different at time of transaction. This is mostly due to rounding issues market conditions.</p>
         </div>

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -140,10 +140,10 @@ function Trade(props) {
         <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Start new trade pair" />
         <div className="boxed dark">
           <h4 className="title">New position</h4>
-          <p className="info"><strong>BUY*:</strong> ${(price * transactionAmount)}</p>
+          <p className="info"><strong>BUY*:</strong> ${Math.round(price * transactionAmount * 100) / 100}</p>
           <p className="info"><strong>SELL*:</strong>${(Math.round((price* transactionAmount * (TradePairRatio + 100))) / 100)}</p>
           {/* todo - currently using .005 as the fee multiplier. Should GET account info from coinbase and use that instead */}
-          <p className="info"><strong>FEE*:</strong> ${(price * transactionAmount * .005)}</p>
+          <p className="info"><strong>FEE*:</strong> ${Math.round(price * transactionAmount * .5) / 100}</p>
           <p className="info"><strong>PAIR MARGIN*:</strong> ${(Math.round(( ((price* transactionAmount * (TradePairRatio))) - (price * transactionAmount) )*100))/100}</p>
           {/* todo - currently using .005 as the fee multiplier. Should GET account info from coinbase and use that instead */}
           <p className="info"><strong>PAIR PROFIT*:</strong> ${(Math.round(( (Math.round((price* transactionAmount * (TradePairRatio + 100))) / 100) - (price * transactionAmount)  - (price * transactionAmount * .005) * 2)*100))/100}</p>

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -139,16 +139,21 @@ function Trade(props) {
         <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Start new trade pair" />
         <div className="boxed dark">
           <h4 className="title">New position</h4>
-          <p className="info"><strong>BUY:</strong> ${(transactionPrice * transactionAmount)}</p>
-          <p className="info"><strong>SELL:</strong>${(Math.round((transactionPrice* transactionAmount * (TradePairRatio + 100))) / 100)}</p>
+          <p className="info"><strong>BUY*:</strong> ${(transactionPrice * transactionAmount)}</p>
+          <p className="info"><strong>SELL*:</strong>${(Math.round((transactionPrice* transactionAmount * (TradePairRatio + 100))) / 100)}</p>
+          {/* todo - currently using .005 as the fee multiplier. Should GET account info from coinbase and use that instead */}
           <p className="info"><strong>FEE*:</strong> ${(transactionPrice * transactionAmount * .005)}</p>
+          <p className="info"><strong>PAIR MARGIN*:</strong> ${(Math.round(( ((transactionPrice* transactionAmount * (TradePairRatio))) - (transactionPrice * transactionAmount) )*100))/100}</p>
+          {/* todo - currently using .005 as the fee multiplier. Should GET account info from coinbase and use that instead */}
+          <p className="info"><strong>PAIR PROFIT*:</strong> ${(Math.round(( (Math.round((transactionPrice* transactionAmount * (TradePairRatio + 100))) / 100) - (transactionPrice * transactionAmount)  - (transactionPrice * transactionAmount * .005) * 2)*100))/100}</p>
+
           <p className="info">
             This will tell coinbot to start trading {transactionAmount} BTC
             between the low purchase price of ${transactionPrice} and
             the high sell price of ${(Math.round((transactionPrice * (TradePairRatio + 100))) / 100)}.
             The value in USD for the initial transaction will be about ${((Math.round((transactionPrice * transactionAmount) * 100)) / 100)}.
           </p>
-          <p className="small">*Fee is estimated and may be different at time of transaction.</p>
+          <p className="small info">*Costs, fees, margin, and profit, are estimated and may be different at time of transaction. This is mostly due to rounding issues market conditions.</p>
         </div>
       </form>
       {/* </div> */}

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -17,6 +17,7 @@ function Trade(props) {
   // of bitcoin, rounded to the closest $100
   const [transactionSide, setTransactionSide] = useState('buy');
   const [transactionPrice, setTransactionPrice] = useState(30000);
+  const [flippedPrice, setFlippedPrice] = useState(30000);
   const [transactionAmount, setTransactionAmount] = useState(0.001);
   const [transactionProduct, setTransactionProduct] = useState('BTC_USD');
   const [TradePairRatio, setTradePairRatio] = useState('BTC_USD');
@@ -39,73 +40,73 @@ function Trade(props) {
     <div className="Trade" >
       <h3 className="title">New Trade Position</h3>
       {/* <div> */}
-        {/* form with a single input. Input takes a price point at which 
+      {/* form with a single input. Input takes a price point at which 
           to make a trade */}
-        <form className="new-trade-form" onSubmit={submitTransaction} >
-          <div className="number-inputs">
-            {/* input for setting the price/BTC per transaction. Can be adjusted in $500 steps, or manually input */}
-            <label htmlFor="price">
-              Trade price per 1 BTC (in USD):
-              <input
-                type="number"
-                name="transaction_price"
-                value={transactionPrice}
-                // todo - this could possibly be changed to 100, or add a selector menu thing to toggle between different amounts
-                step={100}
-                required
-                onChange={(event) => setTransactionPrice(event.target.value)}
-              />
+      <form className="new-trade-form" onSubmit={submitTransaction} >
+        <div className="number-inputs">
+          {/* input for setting the price/BTC per transaction. Can be adjusted in $500 steps, or manually input */}
+          <label htmlFor="transaction_price">
+            Trade price per 1 BTC (in USD):
             </label>
-            <div className="increment-buttons">
-              <div className="increase">
-                <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 1000)} value="+1000"></input>
-                <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 100)} value="+100"></input>
-                <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 10)} value="+10"></input>
-              </div>
-              <div className="decrease">
-                <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 1000)} value="-1000"></input>
-                <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 100)} value="-100"></input>
-                <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 10)} value="-10"></input>
-              </div>
+            <input
+              type="number"
+              name="transaction_price"
+              value={Number(transactionPrice)}
+              // todo - this could possibly be changed to 100, or add a selector menu thing to toggle between different amounts
+              step={100}
+              required
+              onChange={(event) => setTransactionPrice(event.target.value)}
+            />
+          <div className="increment-buttons">
+            <div className="increase">
+              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 1000)} value="+1000"></input>
+              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 100)} value="+100"></input>
+              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice + 10)} value="+10"></input>
+            </div>
+            <div className="decrease">
+              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 1000)} value="-1000"></input>
+              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 100)} value="-100"></input>
+              <input type="button" onClick={(event) => setTransactionPrice(transactionPrice - 10)} value="-10"></input>
             </div>
           </div>
-          <div className="number-inputs">
-            {/* input for setting how much bitcoin should be traded per transaction at the specified price */}
-            <label htmlFor="amount">
-              Trade amount (in BTC):
-              <input
-                type="number"
-                name="transaction_amount"
-                value={transactionAmount}
-                step={0.001}
-                required
-                onChange={(event) => setTransactionAmount(event.target.value)}
-              />
-            </label>
-            <div className="increment-buttons">
-              <div className="increase">
-                <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 1000) /1000)} value="+1"></input>
-                <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 100) /1000)} value="+.1"></input>
-                <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 10) / 1000)} value="+.01"></input>
-                <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 1) / 1000)} value="+.001"></input>
-              </div>
-              <div className="decrease">
-                <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 1000) / 1000)} value="-1"></input>
-                <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 100) / 1000)} value="-.1"></input>
-                <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 10) / 1000)} value="-.01"></input>
-                <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 1) / 1000)} value="-.001"></input>
-              </div>
+        </div>
+        <div className="number-inputs">
+          {/* input for setting how much bitcoin should be traded per transaction at the specified price */}
+          <label htmlFor="transaction_amount">
+            Trade amount (in BTC):
+          </label>
+          <input
+            type="number"
+            name="transaction_amount"
+            value={Number(transactionAmount)}
+            // step={0.001}
+            required
+            onChange={(event) => setTransactionAmount(event.target.value)}
+          />
+          <div className="increment-buttons">
+            <div className="increase">
+              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 1000) / 1000)} value="+1"></input>
+              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 100) / 1000)} value="+.100"></input>
+              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 10) / 1000)} value="+.010"></input>
+              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 + 1) / 1000)} value="+.001"></input>
+            </div>
+            <div className="decrease">
+              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 1000) / 1000)} value="-1"></input>
+              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 100) / 1000)} value="-.100"></input>
+              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 10) / 1000)} value="-.010"></input>
+              <input type="button" onClick={(event) => setTransactionAmount(Math.round(transactionAmount * 1000 - 1) / 1000)} value="-.001"></input>
             </div>
           </div>
-          {/* display some details about the new transaction that is going to be made */}
-          <input className="btn-send-trade" type="submit" name="submit" value="Send new trade position" />
-        </form>
-          <p className="trade-description">
-            This will tell coinbot to start trading {transactionAmount} BTC
-            between the low purchase price of ${transactionPrice} and
-            the high sell price of ${((Math.round((transactionPrice * 1.03) * 100)) / 100)}.
-            The value in USD for the initial transaction will be about ${((Math.round((transactionPrice * transactionAmount) * 100)) / 100)}.
-          </p>
+        </div>
+        {/* display some details about the new transaction that is going to be made */}
+      <p className="trade-description">
+        This will tell coinbot to start trading {transactionAmount} BTC
+        between the low purchase price of ${transactionPrice} and
+        the high sell price of ${((Math.round((transactionPrice * 1.03) * 100)) / 100)}.
+        The value in USD for the initial transaction will be about ${((Math.round((transactionPrice * transactionAmount) * 100)) / 100)}.
+      </p>
+        <input className="btn-send-trade" type="submit" name="submit" value="Send new trade position" />
+      </form>
       {/* </div> */}
     </div>
   );

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -132,13 +132,13 @@ function Trade(props) {
 
 
         {/* display some details about the new transaction that is going to be made */}
+        <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Send new trade position" />
       <p className="trade-description">
         This will tell coinbot to start trading {transactionAmount} BTC
         between the low purchase price of ${transactionPrice} and
         the high sell price of ${((Math.round((transactionPrice * 1.03) * 100)) / 100)}.
         The value in USD for the initial transaction will be about ${((Math.round((transactionPrice * transactionAmount) * 100)) / 100)}.
       </p>
-        <input className="btn-send-trade btn-blue" type="submit" name="submit" value="Send new trade position" />
       </form>
       {/* </div> */}
     </div>

--- a/src/components/TradeList/TradeList.css
+++ b/src/components/TradeList/TradeList.css
@@ -1,0 +1,8 @@
+.TradeList {
+    grid-row: 2/4;
+    grid-column: 2 / 3;
+}
+
+.single-trade {
+    /* width: 100%; */
+}

--- a/src/components/TradeList/TradeList.css
+++ b/src/components/TradeList/TradeList.css
@@ -2,7 +2,3 @@
     grid-row: 2/4;
     grid-column: 3 / 4;
 }
-
-.single-trade {
-    /* width: 100%; */
-}

--- a/src/components/TradeList/TradeList.css
+++ b/src/components/TradeList/TradeList.css
@@ -1,6 +1,6 @@
 .TradeList {
     grid-row: 2/4;
-    grid-column: 2 / 3;
+    grid-column: 3 / 4;
 }
 
 .single-trade {

--- a/src/components/TradeList/TradeList.js
+++ b/src/components/TradeList/TradeList.js
@@ -7,7 +7,9 @@ function TradeList() {
   const dispatch = useDispatch();
 
   return (
-    <div className="TradeList boxed">
+    <div className="TradeList boxed tall dark">
+      <SingleTrade />
+      <SingleTrade />
       <SingleTrade />
       <SingleTrade />
       <SingleTrade />

--- a/src/components/TradeList/TradeList.js
+++ b/src/components/TradeList/TradeList.js
@@ -15,6 +15,7 @@ function TradeList() {
       <SingleTrade />
       <SingleTrade />
       <SingleTrade />
+      <center><p>Robot goes here</p></center>
       <SingleTrade />
       <SingleTrade />
       <SingleTrade />

--- a/src/components/TradeList/TradeList.js
+++ b/src/components/TradeList/TradeList.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
+import SingleTrade from '../SingleTrade/SingleTrade'
 import './TradeList.css'
 
 function TradeList() {
@@ -7,7 +8,17 @@ function TradeList() {
 
   return (
     <div className="TradeList boxed">
-      <p className="single-trade">LIST OF TRADES GOES HERE</p>
+      <SingleTrade />
+      <SingleTrade />
+      <SingleTrade />
+      <SingleTrade />
+      <SingleTrade />
+      <SingleTrade />
+      <SingleTrade />
+      <SingleTrade />
+      <SingleTrade />
+      <SingleTrade />
+
     </div>
   )
 }

--- a/src/components/TradeList/TradeList.js
+++ b/src/components/TradeList/TradeList.js
@@ -1,0 +1,15 @@
+import React, { useState } from 'react';
+import { connect, useDispatch } from 'react-redux';
+import './TradeList.css'
+
+function TradeList() {
+  const dispatch = useDispatch();
+
+  return (
+    <div className="TradeList boxed">
+      <p className="single-trade">LIST OF TRADES GOES HERE</p>
+    </div>
+  )
+}
+
+export default TradeList;

--- a/src/components/Updates/Updates.css
+++ b/src/components/Updates/Updates.css
@@ -1,4 +1,4 @@
 .Updates {
     grid-row-start: 4;
-    grid-column: 2 / 4;
+    grid-column: 1 / 4;
 }

--- a/src/components/Updates/Updates.css
+++ b/src/components/Updates/Updates.css
@@ -1,4 +1,5 @@
 .Updates {
-    grid-row-start: 4;
-    grid-column: 1 / 4;
+    grid-row: 4;
+    grid-column: 2 / 5;
+    height: fit-content;
 }

--- a/src/components/Updates/Updates.js
+++ b/src/components/Updates/Updates.js
@@ -24,10 +24,10 @@ function Updates() {
 
   return (
     // show messages on screen
-    <div className="Updates">
-      <h3>Checking trade:</h3>
-      <p>Trade id: {exchangeUpdate.id} -- Price per BTC: {exchangeUpdate.price} -- Size: {exchangeUpdate.size} BTC -- Buy/Sell: {exchangeUpdate.side}</p>
-      <p>Trade is settled: {exchangeUpdate.settled ? "YES :)" : "no :("}</p>
+    <div className="Updates boxed">
+      <h3 className="title">Coinbot message board:</h3>
+      <p>Trade id: {exchangeUpdate.id} -- Price per BTC: {exchangeUpdate.price} -- Size: {exchangeUpdate.size} BTC -- Buy/Sell: {exchangeUpdate.side}
+         -- Settled: {exchangeUpdate.settled ? "YES :)" : "no :("}</p>
     </div>
   );
 }

--- a/src/redux/sagas/trade.saga.js
+++ b/src/redux/sagas/trade.saga.js
@@ -13,6 +13,7 @@ function* toggleBot(action) {
 
 function* startTrade(action) {
     try {
+        console.log('payload is:', action.payload);
         const response = yield axios.post(`/api/trade/order`, action.payload);
         console.log('response is.....', response);
     } catch (error) {

--- a/todo.md
+++ b/todo.md
@@ -5,27 +5,27 @@
 - [] display currently available funds
 - [] display all currently open trades
     - [] current side (buying/selling)
-    - [] size in btc and usd
-    - [] high price (to sell at)
-    - [] low price (to buy at)
+    - [x] size in btc and usd
+    - [x] high price (to sell at)
+    - [x] low price (to buy at)
     - [] cancel button to abandon position
         - triggers cancel function on backend
     - example: `<buying 0.001 BTC for $32 -- high: 32,000 -- low: 31,000 -- [CANCEL] >`
         - this will show which prices the bot is bouncing between
-- [] input for new price point to auto trade at
+- [x] input for new price point to auto trade at
     - manually triggers transaction function on backend
     - initially this will assume an abundance of USD, and trigger a buy transaction.
     - Stretch goal: add buy and sell buttons to account for either an abundance of USD or BTC
     - Stretch goal: bot will occasionally check available account balances against current market values, and if there is enough surplus of USD or BTC, will automatically trigger a buy or sell transaction respectively. This allows for automatic deposits from a bank or bitcoin miner to be taken care of effortlessly by the bot at current prices, which are most likely to be profitable. This feature should be able to toggle on and off.
-- [] toggle to turn trading on and off
-    - [] send POST request to server to handle toggle and trade loop function
+- [x] toggle to turn trading on and off
+    - [x] send POST request to server to handle toggle and trade loop function
 - [] display current trading status. Maybe should be combined with trading toggle by toggling button color between green and red.
 ### Reducers
 - [] status reducer - hold current price of bitcoin, and status of bot (on/off)
 - [] trade reducer - hold open trades to be displayed on Trade component
 ### Components
-- [] Home
-- [] Trade - shows all trades and status of bot
+- [x] Home
+- [x] Trade - shows all trades and status of bot
 - [] SingleTrade - show a single trade
 - [] 
 - [] 
@@ -56,7 +56,7 @@
 - [] trade/order DELETE - takes in an order ID to be canceled on CB and then deleted from the DB
 
 ### Functions
-- [] set up auto trader
+- [x] set up auto trader
     - ### transaction function
         - [x] set up POST route at api/trade/order
         - [x] takes in a price param (number as a string), a value (number as a string), 
@@ -70,11 +70,11 @@
         - [x] wait n seconds and check on orders
             - [x] pull all open orders from db and loop through each one
             - [x] request order info from Coinbase (CB) API based on order ID from DB
-            - [] check if order settled. If order has gone through:
-                - [] initiate opposite type of sale (sell/buy) order with sell function. So if a buy was just detected as complete, initiate a sell. If a sell was completed, initiate a buy.
+            - [x] check if order settled. If order has gone through:
+                - [x] initiate opposite type of sale (sell/buy) order with sell function. So if a buy was just detected as complete, initiate a sell. If a sell was completed, initiate a buy.
                     - if selling was completed, divide original order's sale price by 1.03 to get the price for the new buy order. This will create a buy at 3% lower cost than the sale that was just made.
                     - if buying was completed, multiply the original order's purchase price by 1.03 for a new sale price that is 3% higher.
-                - [] set status for that order ID in DB to complete. this needs to happen last so if there is an error creating the new order, the function will just check on it later
+                - [x] set status for that order ID in DB to complete. this needs to happen last so if there is an error creating the new order, the function will just check on it later
                     - if order has not gone through, just ignore and loop to next order. No 'else' statement.
 
 - ### cancel position function
@@ -85,9 +85,9 @@
     - [] if the request fails because the order has already gone through, send error response so an alert can be shown on the front end
 
 - ### control for turning bot on and off
-    - [] set up POST route at api/settings/toggle
-        - [] when route is hit, toggle "trading" variable between true/false. Aka, trading = !trading
-        - [] if trading is true, call trade loop function to watch order status and wait for transaction to go through
+    - [x] set up POST route at api/settings/toggle
+        - [x] when route is hit, toggle "trading" variable between true/false. Aka, trading = !trading
+        - [x] if trading is true, call trade loop function to watch order status and wait for transaction to go through
 
 ### Misc
 - [x] connect to coinbase API
@@ -98,11 +98,11 @@
 
 
 - ### Fewer API calls
-    - Pull all open orders from CB into an array
-    - Pull all open orders from DB into a second array
-    - Compare both arrays, pop orders out of the DB array if they also exist in the CB array
-    - The orders that remain in the DB array will be settled in CB, and can be fed to the loop.
-    - This makes much fewer API calls 
+    - [x] Pull all open orders from CB into an array
+    - [x] Pull all open orders from DB into a second array
+    - [x] Compare both arrays, pop orders out of the DB array if they also exist in the CB array
+        - The orders that remain in the DB array will be settled in CB, and can be fed to the loop.
+        - This makes much fewer API calls 
 
 - ### Trade tier awareness
     - Build logic into the bot to account for different fee pricing tiers
@@ -111,6 +111,6 @@
 
 - ### Store both original buy and sell positions
     - Running math in JS for pricing is not accurate and could allow the positions to creep
-    - upper and lower prices should be calculated before the trade is sent and stored in the DB
-    - the loop will reference the stored values for the new trades instead of multiplying and rounding with each trade
-    - this should also slightly improve performance because there are fewer calculations per trade
+    - [x] upper and lower prices should be calculated before the trade is sent and stored in the DB
+    - [x] the loop will reference the stored values for the new trades instead of multiplying and rounding with each trade
+        - this should also slightly improve performance because there are fewer calculations per trade


### PR DESCRIPTION
Coinbot no longer runs a percentage calculation on each trade flip. Instead, the buy and sell prices are calculated on the dom and stored in the db. The values are passed along through the loop to every new trade. This helps prevent JavaScript's floating point math issues from slowly creeping trade prices away from their original positions.

Interface is also very much improved, and has dummy components to show what the display should end up looking like. It is responsive to different screen sizes to an extent, but not well on smaller mobile devices.

Known issue: clicking the toggle button too quickly can actually case the bot to run two loops at once, running the account out of available funds. No big deal. DON'T TOGGLE THE BOT TOO FAST.