### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,67 @@
 
 # Coinbot
 
-Bitcoin trading bot built for the Coinbase Pro cryptocurrency exchange. Strategy is built on the creation of a trade-pair. Two order price positions, a buy price and a sell price, are tied together in the coinbot's database. The bot keeps track of which "side" is currently on order on Coinbase. When the coinbot detects a trade has settled on the exchange, it flips sides on the trade.
+Coinbot is a Bitcoin trading bot project built for the Coinbase Pro cryptocurrency exchange. 
 
-## DISCLAIMER
-This is an experimental bot. It requires a connection to a Coinbase Pro account, and has the ability to handle real money. Coinbase provides a sandbox API for testing purposes. It is recommended only to use the sandbox API with this bot as a demonstration of what is possible with the Coinbase API. Any use of the software provided in this repository is the responsibility of the user, and the developers of the software cannot be held responsible for any financial operations made with the software, or harm done to your computer as a result of using the software. Use of this software does not come with any guarantee of profits, losses, fees, taxes, or other financial consequences. Bitcoin and other cryptocurrencies may be taxed. Trading cryptocurrency is a risk taken by those making the trades. No financial advice is given in regards to the use of this software.
+The strategy is based on the creation of trade-pair values. A trade-pair is the combination of two precalculated order price positions, a "buy" price and a "sell" price, that are stored in the coinbot's local database. The buy price should always be lower than the sell price, and the difference between the two should cover the cost of exchange fees. The bot keeps track of which "side" (buy or sell) is currently on order on Coinbase. each order is stored locally with the original buy and sell values. When the coinbot detects a trade has settled on the exchange, it flips sides on the trade by creating a new trade on the other side. 
+
+So when a "buy" is settled, another order will immediately be placed as a "sell". The prices of each of these orders are stored as the values of the trade-pair. When a buy order and a sell order each go through from the same trade-pair values, a profit is made. The two transactions that contributed to the profit are the trade-pair. The volume of the trade-pair does not matter so much, as fees are calculated by percentage. A smaller volume allows for greater distribution of trade-pair positions.
+
+Placing dozens of trade-pairs at many different price points allows the bot to capture smaller but more frequent profits. The huge price swings that occasionaly make someone rich are notable in their own light, but do not happen frequently at all when compared to the smaller $400 - $3,000 swings that happen on a daily basis. The coinbot does not care, and allows for both of these strategies to work.
+
+For example: A trade-pair could be set up between the prices of $10,000 and $100,000, and return a huge profit if the price of Bitcoin hits both sides. Or it could be set up between $30,000 and $31,000 for much smaller, but more frequent profits as the price staggers past them. In testing, the latter strategy has shown to be effective.
+
+But again, the coinbot does not care. Nor do the developers. 
+
+However, a higher amount of open trades does increase the amount of processing done by the bot. The effects of this are unknown, but this is not a high-speed bot on a Wall Street exchange. It was made for a slow and unreliable home internet connection. On that note, one of the developers uses a satellite connection (Starlink) and a Raspberry Pi. It hasn't been an issue. The bot keeps local copies of the trades it makes, places limit orders, and does not rely on the ability to react quickly to incoming market data. If the internet connection is cut off, the limit orders will still go through on Coinbase, and the will simply check and react to them later when the internet is restored.
+
+## `DISCLAIMER`
+
+This is an experimental bot. It requires a connection to a Coinbase Pro account, and has the ability to handle real money. Coinbase provides a sandbox API for testing purposes. It is recommended only to use the sandbox API with this bot as a demonstration of what is possible with the Coinbase API. Any use of the software provided in this repository is the responsibility of the user, and the developers of the software cannot be held responsible for any financial operations made with the software, or harm done to your computer as a result of using the software. Use of this software does not come with any guarantee of profits, losses, fees, taxes, or other financial consequences. Bitcoin and other cryptocurrencies may be taxed. Trading cryptocurrency is a risk taken by those making the trades. No financial advice is given in regards to the use of this software. 
 
 You trade at your own risk.
+
+There are also currently no security features built in to the coinbot. DO NOT host it in the cloud or on any device that can be accessed from the internet, from the intranet, or by anyone who you do not want to be able access it.
+
+## Advantages
+
+This is a fairly low-risk strategy, as it requires no statistical analisys or market data. There is no risk of guessing trends incorrectly because the coinbot does not guess. It works off of predetermined prices. Profits are made when the price of Bitcoin passes the "buy" and "sell" prices of a trade-pair in that order. If left alone, the coinbot will do this automatically at the set price points as long as the price of bitcoin is hitting them. The coinbot actually benefits from higher volitility and large fast price swings because it increases the chances that the trade-pair values will be hit.
+
+## Disadvantages
+
+A notable disadvantage of this strategy is that when the price takes an upward trend, the coinbot will sell at a fixed price regardless. This slows down the potential rate of profits compared to strategies that attempt to calculate the tops of market curves. 
+
+It also does not take into account market volumes, or the bird-themed social media accounts of billionaire entrepreneurs. That's not what this project is about. :bird:
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## `Features`
 
-### Create new trade pairs
+### Web-based Interface
+
+Use and configuration for the coinbot is done from a 
+
+### Create New Trade Pairs
+
+New trade-pair values can be created from the interface. There is a calculator to determine both sides of the trade-pair, and estimate fees and profits. Note that these are an estimation, and nothing is guaranteed on the behalf of the developers.
+
+### Toggle Bot Button
+
+There is a big red button on the interface for turning the bot on and off. This makes it easy to pause trading if, say, you just need some time to think.
+
+### More to Come
+- Total profit estimation
+- Live status updates from the coinbot
+- List of open orders
+- Order cancelation from interface
+    - This will notably include auto cancellation, where the bot will wait to cancel the trade-pair if it is a sell order. Buy orders will be canceled immediatly. This ensures that a position will only be cancelled after a profit has been made, and helps to prevent losses due to trading fees.
+- Fee adjustment
+    - Currently the coinbot uses the .5% fee of the first tier when calculating fees and profits. This will change so that the coinbot will check what the currently connected account fees are, and modify the calculation appropriately.
 
 ## `Important notes`
-- In it's current state, there is no option to cancel an order from the Coinbot app. Coinbot also does not have a way to detect if an order has been canceled from the coinbase website. If that happens, Coinbot will throw an error and will either stop, or continue checking the cancelled order and throwing the error.
+- In it's current state, there is no option to cancel an order from the Coinbot app. Coinbot does, however, detect if an order has been canceled from the coinbase website. When an order is canceled, Coinbase returns a 404 when looking up the status of the trade. If that happens, Coinbot will delete the trade from it's own database.
+
+- The coinbot will not detect new trades placed on Coinbase manually from the connected Coinbase account. It is recommended to create a separate profile on Coinbase exclusively for the coinbot to prevent accidental cancellation of the coinbot's trades.
 
 ## `Setup`
 
@@ -37,13 +83,18 @@ Postgres should be setup and a new database should be created with the name "coi
 
 In the project directory, you can run:
 
+### `yarn server`
+
+Runs the express server in the backend.\
+This is where the coinbot lives, and must be done.
+
 ### `yarn start`
 
-Runs the app in the development mode.\
+Runs the web app interface in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 The page will reload if you make edits.\
-You will also see any lint errors in the console.
+You will also see any lint errors in the console. Currently, the coinbot must be toggled on from the web interface before it can start trading, even if trade-pairs have already been made. So this also must be done for now.
 
 ### `yarn test`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Coinbot
 
-Bitcoin trading bot built for coinbase. Strategy is to automatically buy bitcoin and then put in a sell order at a higher price. That sale will then trigger a buy order at a lower price, etc. 
+Bitcoin trading bot built for the Coinbase Pro cryptocurrency exchange. Strategy is built on the creation of a trade-pair. Two order price positions, a buy price and a sell price, are tied together in the coinbot's database. The bot keeps track of which "side" is currently on order on Coinbase. When the coinbot detects a trade has settled on the exchange, it flips sides on the trade.
 
 ## DISCLAIMER
 This is an experimental bot. It requires a connection to a Coinbase Pro account, and has the ability to handle real money. Coinbase provides a sandbox API for testing purposes. It is recommended only to use the sandbox API with this bot as a demonstration of what is possible with the Coinbase API. Any use of the software provided in this repository is the responsibility of the user, and the developers of the software cannot be held responsible for any financial operations made with the software, or harm done to your computer as a result of using the software. Use of this software does not come with any guarantee of profits, losses, fees, taxes, or other financial consequences. Bitcoin and other cryptocurrencies may be taxed. Trading cryptocurrency is a risk taken by those making the trades. No financial advice is given in regards to the use of this software.
@@ -13,7 +13,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## `Features`
 
-List of features coming soon...
+### Create new trade pairs
 
 ## `Important notes`
 - In it's current state, there is no option to cancel an order from the Coinbot app. Coinbot also does not have a way to detect if an order has been canceled from the coinbase website. If that happens, Coinbot will throw an error and will either stop, or continue checking the cancelled order and throwing the error.

--- a/server/modules/robot/exchange.js
+++ b/server/modules/robot/exchange.js
@@ -61,7 +61,7 @@ const exchange = async (ordersToCheck) => {
         }
       })
       .catch((error) => {
-        if (error.data.message) {
+        if ((error.data !== undefined) && (error.data.message !== undefined)) {
           console.log('error message, end of loop:', error.data.message);
           // orders that have been canceled are deleted from coinbase and return a 404.
           // error handling should delete them so they are not counted toward profits if simply marked settled

--- a/server/modules/robot/flipTrade.js
+++ b/server/modules/robot/flipTrade.js
@@ -22,7 +22,7 @@ const flipTrade = (dbOrder, cbOrder) => {
     } else {
       // if it was a sell, buy for less. divide old price
       tradeDetails.side = "buy"
-      tradeDetails.price = original_buy_price;
+      tradeDetails.price = dbOrder.original_buy_price;
       console.log('buying');
     }
     // return the tradeDetails object

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -144,10 +144,9 @@ function Trade(props) {
           <p className="info"><strong>SELL*:</strong>${(Math.round((price* transactionAmount * (TradePairRatio + 100))) / 100)}</p>
           {/* todo - currently using .005 as the fee multiplier. Should GET account info from coinbase and use that instead */}
           <p className="info"><strong>FEE*:</strong> ${Math.round(price * transactionAmount * .5) / 100}</p>
-          <p className="info"><strong>PAIR MARGIN*:</strong> ${(Math.round(( ((price* transactionAmount * (TradePairRatio))) - (price * transactionAmount) )*100))/100}</p>
+          <p className="info"><strong>PAIR MARGIN*:</strong> ${(Math.round(( ((price* transactionAmount * (TradePairRatio + 100))) / 100 - (price * transactionAmount) )*100))/100}</p>
           {/* todo - currently using .005 as the fee multiplier. Should GET account info from coinbase and use that instead */}
           <p className="info"><strong>PAIR PROFIT*:</strong> ${(Math.round(( (Math.round((price* transactionAmount * (TradePairRatio + 100))) / 100) - (price * transactionAmount)  - (price * transactionAmount * .005) * 2)*100))/100}</p>
-
           <p className="info">
             This will tell coinbot to start trading {transactionAmount} BTC
             between the low purchase price of ${price} and

--- a/src/components/Updates/Updates.js
+++ b/src/components/Updates/Updates.js
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import io from "socket.io-client";
 import './Updates.css'
-const ENDPOINT = "http://localhost:5000";
-const socket = io(ENDPOINT, { transports: ['websocket'] });
+// const ENDPOINT = "http://localhost:5000";
+// const socket = io(ENDPOINT, { transports: ['websocket'] });
 // adding cors arg in server let's us get rid of the transports arg
 // const socket = io(ENDPOINT);
 
@@ -11,16 +11,16 @@ function Updates() {
   const [exchangeUpdate, setExchangeUpdate] = useState("");
 
   // console log any messages from server
-  socket.on('exchangeUpdate', data => {
-    console.log(data);
-    setExchangeUpdate(data)
-    // console.log('update from the loop', exchangeUpdate);
-  });
+  // socket.on('exchangeUpdate', data => {
+  //   console.log(data);
+  //   setExchangeUpdate(data)
+  //   // console.log('update from the loop', exchangeUpdate);
+  // });
 
-  socket.on('message', message => {
-    // setaMessage(message.message);
-    console.log(message.message);
-  });
+  // socket.on('message', message => {
+  //   // setaMessage(message.message);
+  //   console.log(message.message);
+  // });
 
   return (
     // show messages on screen


### PR DESCRIPTION
Fixes a couple small bugs and updates the readme. One bug prevented the second flip of a trade. While this did break the app, it did not cause loss of profits as the coinbot would buy, then sell, then crash. It would make one profit per trade pair. 

However this did mean that a user could accidentally place another trade-pair position with the cash that hasn't been spent on the flipped trade. This could place too many open trades in the coinbot database. Database should be reset with this merge.