### PR TITLE
Better estimate accuracy 

### DIFF
--- a/server/modules/robot/flipTrade.js
+++ b/server/modules/robot/flipTrade.js
@@ -11,10 +11,6 @@ const flipTrade = (dbOrder) => {
       size: dbOrder.size, // BTC
       product_id: dbOrder.product_id,
     };
-  
-    // todo - need to store more info in db
-    // need the trade-pair margin instead of calculating new price each time
-  
     // add buy/sell requirement and price
     if (dbOrder.side === "buy") {
       // if it was a buy, sell for more. multiply old price

--- a/server/routes/trade.router.js
+++ b/server/routes/trade.router.js
@@ -70,21 +70,46 @@ router.delete('/', rejectUnauthenticated, (req, res) => {
       console.log('order was deleted successfully from cb', data);
       const queryText = `DELETE from "orders" WHERE "id"=$1;`;
       pool.query(queryText, [data])
-      .then(() => {
-        socketClient.emit('update', {
-          message: `order was tossed out of ol' databanks`,
-          orderUpdate: true
-        });
-        console.log('deleted from db as well');
-        res.sendStatus(200);
-      })
+        .then(() => {
+          socketClient.emit('update', {
+            message: `order was tossed out of ol' databanks`,
+            orderUpdate: true
+          });
+          console.log('deleted from db as well');
+          res.sendStatus(200);
+        })
     })
     .catch((error) => {
-      console.log('something failed', error);
-      res.sendStatus(500)
+
+      if (error.data && error.data.message) {
+        console.log('error message, trade router DELETE:', error.data.message);
+      }
+      // orders that have been canceled are deleted from coinbase and return a 404.
+      // error handling should delete them from db and not worry about coinbase since there is no other way to delete
+      // but also send one last delete message to Coinbase just in case it finds it again, but with no error checking
+      if (error.data.message === 'order not found') {
+        console.log('order not found in account. deleting from db', orderId);
+        const queryText = `DELETE from "orders" WHERE "id"=$1;`;
+        pool.query(queryText, [orderId])
+          .then(() => {
+            console.log('exchange was tossed lmao');
+            socketClient.emit('update', {
+              message: `exchange was tossed out of the ol' databanks`,
+              orderUpdate: true
+            });
+            res.sendStatus(200)
+          })
+          .catch((error) => {
+            console.log(error);
+            res.sendStatus(500)
+          })
+      } else {
+        console.log('something failed', error);
+        res.sendStatus(500)
+      }
+
     });
 });
-
 
 
 

--- a/server/routes/trade.router.js
+++ b/server/routes/trade.router.js
@@ -8,7 +8,7 @@ const socketClient = require('../modules/socketClient');
 const toggleCoinbot = require('../modules/robot/toggleCoinbot');
 
 
-// todo - POST route for auto trading
+// POST route for turning bot on and off
 router.post('/toggle', rejectUnauthenticated, (req, res) => {
   // When this route is hit, it turns on and off the trading loop
   console.log('toggle route');

--- a/src/components/Messages/Messages.js
+++ b/src/components/Messages/Messages.js
@@ -11,20 +11,19 @@ function Updates() {
     // socket may not exist on page load because it hasn't connected yet
     if (socket == null) return;
     socket.on('message', message => {
-      setMessages(prevMessages => [...prevMessages, message.message]);
+      setMessages(prevMessages => {
+        // keep max messages down to 3 by checking if more than 2 before adding new message
+        if (prevMessages.length > 2) {
+          prevMessages.shift();
+        }
+        return [...prevMessages, message.message]
+      });
     });
     // this will remove the listener when component rerenders
     return () => socket.off('message')
     // useEffect will depend on socket because the connection will 
     // not be there right when the page loads
   }, [socket]);
-
-  useEffect(() => {
-    // todo - figure out why this is 2 instead of 3. Something about renders
-    if (messages.length > 2) {
-      messages.shift();
-    }
-  }, [messages])
 
   return (
     // show messages on screen

--- a/src/components/SingleTrade/SingleTrade.js
+++ b/src/components/SingleTrade/SingleTrade.js
@@ -13,7 +13,7 @@ function SingleTrade(props) {
     //   return
     // }
     // this formula is ridiculous but hey, at least I didn't inject it right into the html, right?
-    const profit = Math.round((((props.order.original_sell_price * props.order.size - props.order.original_buy_price * props.order.size)) - ((props.store.accountReducer.feeReducer.maker_fee_rate * props.order.original_buy_price * props.order.size)+(props.store.accountReducer.feeReducer.maker_fee_rate * props.order.original_sell_price * props.order.size))) * 100) / 100;
+    const profit = Math.round((((props.order.original_sell_price * props.order.size - props.order.original_buy_price * props.order.size)) - ((props.store.accountReducer.feeReducer.maker_fee_rate * props.order.original_buy_price * props.order.size)+(props.store.accountReducer.feeReducer.maker_fee_rate * props.order.original_sell_price * props.order.size))) * 10000) / 10000;
     setProfit(profit);
   }, [props.store.accountReducer, props.order.original_sell_price, props.order.original_buy_price, props.order.size]);
 

--- a/src/components/SingleTrade/SingleTrade.js
+++ b/src/components/SingleTrade/SingleTrade.js
@@ -31,7 +31,7 @@ function SingleTrade(props) {
   }
 
   // todo - probably need to refactor this thing asap. Should use more useState hooks to make these strings a bit less horrifying
-  // postgres is much better at math using exact 
+  // postgres is much better at math using exact
 
   return (
     <div className={`${props.order.side}`}>
@@ -41,10 +41,6 @@ function SingleTrade(props) {
     }
       <p className="single-trade">
         <strong>
-          {/* {(props.order.side === 'sell')
-            ? 'Sell'
-            : 'Buy'
-          }  */}
           Price: </strong>
         {(props.order.side === 'sell')
           ? Number(props.order.original_sell_price)

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -85,7 +85,13 @@ function Status(props) {
         setConnection('Connected!')
         // save price
         // todo - dispatch to store and give button to use current price in trade-pair
-        setBTC_USD_price(data.price)
+        setBTC_USD_price(data.price);
+        dispatch({
+          type: 'SET_TICKER_PRICE',
+          payload: {
+            tickerPrice: data.price
+          }
+        });
         // console.log('ticker', BTC_USD_price);
       }
     })

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -13,7 +13,6 @@ function Status(props) {
   const dispatch = useDispatch();
   const [loopStatus, setLoopStatus] = useState("I count loops");
   const [connection, setConnection] = useState("disconnected");
-  const [BTC_USD_price, setBTC_USD_price] = useState("");
   const [openOrderQuantity, setOpenOrderQuantity] = useState(0);
 
   const socket = useSocket();
@@ -84,8 +83,6 @@ function Status(props) {
       } else {
         setConnection('Connected!')
         // save price
-        // todo - dispatch to store and give button to use current price in trade-pair
-        setBTC_USD_price(data.price);
         dispatch({
           type: 'SET_TICKER_PRICE',
           payload: {
@@ -114,7 +111,7 @@ function Status(props) {
       </h3>
       {/* todo - maybe style in some divider lines here or something */}
       <p className="info"><strong>~~~ BTC-USD ~~~</strong></p>
-      <p className="info">${BTC_USD_price}/coin</p>
+      <p className="info">${props.store.statusReducer.tickerReducer.tickerPrice}/coin</p>
       <p className="info"><strong>~~~ Coinbot ~~~</strong></p>
       <p className="info">{connection}</p>
       <p className="info"><strong>~~~ The Loop ~~~</strong></p>

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -32,6 +32,16 @@ function Trade(props) {
     })
   }
 
+  const getCurrentPrice = () => {
+    // check if the current price has been stored yet to prevent NaN errors
+    if (props.store.statusReducer.tickerReducer.tickerPrice) {
+      // round the price to nearest 100
+      const roundedPrice = Math.round(props.store.statusReducer.tickerReducer.tickerPrice / 100) * 100;
+      // change input box to reflect rounded value
+      setTransactionPrice(roundedPrice)
+    }
+  }
+
   // when the page loads, get the account fees 
   useEffect(() => {
     // getFees()
@@ -57,7 +67,7 @@ function Trade(props) {
           <div className="number-inputs">
             {/* input for setting the price/BTC per transaction. Can be adjusted in $500 steps, or manually input */}
             <label htmlFor="transaction_price">
-              Trade price per 1 BTC (in USD):
+              Trade price per 1 BTC (in USD): <button className="btn-blue" onClick={(event) => getCurrentPrice()}> Get Current (rounded)</button>
             </label>
             <input
               type="number"

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -31,8 +31,9 @@ function Trade(props) {
       }
     })
   }
-
-  const getCurrentPrice = () => {
+  
+  const getCurrentPrice = (event) => {
+    event.preventDefault();
     // check if the current price has been stored yet to prevent NaN errors
     if (props.store.statusReducer.tickerReducer.tickerPrice) {
       // round the price to nearest 100
@@ -67,7 +68,7 @@ function Trade(props) {
           <div className="number-inputs">
             {/* input for setting the price/BTC per transaction. Can be adjusted in $500 steps, or manually input */}
             <label htmlFor="transaction_price">
-              Trade price per 1 BTC (in USD): <button className="btn-blue" onClick={(event) => getCurrentPrice()}> Get Current (rounded)</button>
+              Trade price per 1 BTC (in USD): <button className="btn-blue" onClick={(event) => getCurrentPrice(event)}> Get Current (rounded)</button>
             </label>
             <input
               type="number"
@@ -162,9 +163,9 @@ function Trade(props) {
             <p><strong>Cost at this volume:</strong></p>
             <p className="info"><strong>BUY*:</strong> ${Math.round(price * transactionAmount * 100) / 100}</p>
             <p className="info"><strong>SELL*:</strong>${(Math.round((price * transactionAmount * (tradePairRatio + 100))) / 100)}</p>
-            <p className="info"><strong>FEE*:</strong> ${Math.round(price * transactionAmount * (fees * 100)) / 100}</p>
-            <p className="info"><strong>PAIR MARGIN*:</strong> ${(Math.round((((price * transactionAmount * (tradePairRatio + 100))) / 100 - (price * transactionAmount)) * 100)) / 100}</p>
-            <p className="info"><strong>PAIR PROFIT*:</strong> ${(Math.round((((price * transactionAmount * (tradePairRatio + 100)) / 100) - (price * transactionAmount) - (price * transactionAmount * fees) * 2) * 100)) / 100}</p>
+            <p className="info"><strong>FEE*:</strong> ${Math.round(price * transactionAmount * (fees * 10000)) / 10000}</p>
+            <p className="info"><strong>PAIR MARGIN*:</strong> ${(Math.round((((price * transactionAmount * (tradePairRatio + 100))) / 100 - (price * transactionAmount)) * 10000)) / 10000}</p>
+            <p className="info"><strong>PAIR PROFIT*:</strong> ${(Math.round((((price * transactionAmount * (tradePairRatio + 100)) / 100) - (price * transactionAmount) - (price * transactionAmount * fees) * 2) * 10000)) / 10000}</p>
             {/* <p className="info">The value in USD for the initial transaction will be about ${((Math.round((price * transactionAmount) * 100)) / 100)}.</p> */}
             <p className="small info">*Costs, fees, margin, and profit, are estimated and may be different at time of transaction. This is mostly due to rounding issues market conditions.</p>
           </div>

--- a/src/redux/reducers/_root.reducer.js
+++ b/src/redux/reducers/_root.reducer.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import tradeReducer from './trade.reducer';
+import statusReducer from './status.reducer';
 import accountReducer from './account.reducer';
 import ordersReducer from './orders.reducer';
 
@@ -11,7 +11,7 @@ import ordersReducer from './orders.reducer';
 // Lets make a bigger object for our store, with the objects from our reducers.
 // This is what we get when we use 'state' inside of 'mapStateToProps'
 const rootReducer = combineReducers({
-  tradeReducer,
+  statusReducer,
   accountReducer,
   ordersReducer,
 });

--- a/src/redux/reducers/status.reducer.js
+++ b/src/redux/reducers/status.reducer.js
@@ -2,7 +2,7 @@ import { combineReducers } from 'redux';
 
 // registrationMessage holds the string that will display
 // on the registration screen if there's an error
-const statusReducer = (state = '', action) => {
+const tickerReducer = (state = '', action) => {
     switch (action.type) {
       case 'SET_TICKER_PRICE':
         return action.payload;
@@ -15,6 +15,6 @@ const statusReducer = (state = '', action) => {
   // these will be on the redux state at:
   // state.errors.loginMessage and state.errors.registrationMessage
   export default combineReducers({
-    statusReducer,
+    tickerReducer,
   });
   

--- a/src/redux/reducers/status.reducer.js
+++ b/src/redux/reducers/status.reducer.js
@@ -2,7 +2,7 @@ import { combineReducers } from 'redux';
 
 // registrationMessage holds the string that will display
 // on the registration screen if there's an error
-const tickerReducer = (state = '', action) => {
+const tickerReducer = (state = {}, action) => {
     switch (action.type) {
       case 'SET_TICKER_PRICE':
         return action.payload;

--- a/src/redux/reducers/status.reducer.js
+++ b/src/redux/reducers/status.reducer.js
@@ -2,13 +2,9 @@ import { combineReducers } from 'redux';
 
 // registrationMessage holds the string that will display
 // on the registration screen if there's an error
-const testReducer = (state = '', action) => {
+const statusReducer = (state = '', action) => {
     switch (action.type) {
-      case 'RETURN_TEST_1':
-        return 'TEST 1';
-      case 'RETURN_TEST_2':
-        return 'TEST 2';
-      case 'RETURN_TEST_3':
+      case 'SET_TICKER_PRICE':
         return action.payload;
       default:
         return state;
@@ -19,6 +15,6 @@ const testReducer = (state = '', action) => {
   // these will be on the redux state at:
   // state.errors.loginMessage and state.errors.registrationMessage
   export default combineReducers({
-    testReducer,
+    statusReducer,
   });
   


### PR DESCRIPTION
Adjusted the rounding in the estimate calculator to round to the 1000ths of a dollar, instead of 100ths (cents). Added a button to bring the Trade Price input close to the current price (rounded to nearest $100) so reduce number of clicks on adjustment buttons without entering a price manually.

Bug fixes:
- Message box no longer pops up and down in size when a new message comes in and an old one is deleted
- Reason for randomly dropped orders was caused by incorrect 404 errors from Coinbase. These are believed to show up when a request is made about an order right as it sells. The auto delete feature was removed, but that causes the bot to stop working if an order is canceled from the Coinbase UI, and the order could not be deleted from the db. The delete route has now been modified to detect 404s, will double check with Coinbase once, and then delete the order from the db if it still returns a 404. This way the bot can be made unstuck by deleting problematic orders.