### PR TITLE
Increase order count

### DIFF
--- a/server/modules/robot.js
+++ b/server/modules/robot.js
@@ -594,7 +594,7 @@ async function autoSetup(user, parameters) {
 
   } catch (err) {
     if (err.response?.status === 400) {
-      console.log(err, 'Insufficient funds!');
+      console.log('Insufficient funds! Or too small order or some similar problem');
       socketClient.emit('message', {
         error: `Insufficient funds!`,
         orderUpdate: true

--- a/server/modules/robot.js
+++ b/server/modules/robot.js
@@ -32,6 +32,19 @@ async function syncOrders(userID) {
       // store the lists of orders in the corresponding arrays so they can be compared
       const dbOrders = results[0];
       const cbOrders = results[1];
+
+      // CHECK IF THERE ARE 1000 OPEN ORDERS AND GET MORE FROM CB IF NEEDED
+
+      console.log('this is the newest and oldest order from cb', cbOrders[0], cbOrders[cbOrders.length - 1]);
+
+      const oldestDate = cbOrders[cbOrders.length - 1].created_at;
+
+      
+      const olderOrders = await coinbaseClient.getOpenOrdersBeforeDate(userID, oldestDate);
+      
+      console.log(olderOrders);
+
+
       // compare the arrays and remove any where the ids match in both,
       // leaving a list of orders that are open in the db, but not on cb. Probably settled
       const ordersToCheck = await orderElimination(dbOrders, cbOrders);

--- a/server/modules/robot.js
+++ b/server/modules/robot.js
@@ -613,17 +613,9 @@ async function autoSetup(user, parameters) {
 
 
 const robot = {
-  // the /trade/toggle route will set canToggle to false as soon as it is called so that it 
-  // doesn't call the loop twice. The loop will set it back to true after it finishes a loop
-  canToggle: true,
-  looping: false,
-  loop: 0,
-  busy: 0,
   sleep: sleep,
   flipTrade: flipTrade,
   syncOrders: syncOrders,
-  synching: false,
-  maxHistory: 200,
   processOrders: processOrders,
   syncEverything: syncEverything,
   startSync: startSync,

--- a/src/components/Settings/AutoSetup/AutoSetup.js
+++ b/src/components/Settings/AutoSetup/AutoSetup.js
@@ -14,6 +14,7 @@ function AutoSetup(props) {
   const [tradePairRatio, setTradePairRatio] = useState(1.1);
   const [setupResults, setSetupResults] = useState(1);
   const [autoTradeStarted, setAutoTradeStarted] = useState(false);
+  const [totalTrades, setTotalTrades] = useState(false);
   
   // const [keepTrading, setKeepTrading] = useState(false);
 
@@ -52,7 +53,8 @@ function AutoSetup(props) {
     }
 
 
-    setSetupResults(finalPrice)
+    setSetupResults(finalPrice);
+    setTotalTrades(count);
 
 
   }
@@ -188,6 +190,16 @@ function AutoSetup(props) {
             This will likely be higher if trades are placed higher than the current price of BTC, as they
             will cost less. It can also change if the price of BTC moves up or down significantly while the 
             trades are being set up.
+          </p>
+          <p>
+            Approximate number of trades the setup process will create:
+          </p>
+          <p>
+            <strong>{totalTrades}</strong>
+          </p>
+          <p>
+            However, it will try to stop before there are more than 1999 trades placed. Latency may cause it to 
+            create more, and you may need to delete a few in order to optimize speed.
           </p>
 
         </div>

--- a/src/components/Settings/AutoSetup/AutoSetup.js
+++ b/src/components/Settings/AutoSetup/AutoSetup.js
@@ -34,7 +34,7 @@ function AutoSetup(props) {
     let count = 0;
     setSetupResults(startingValue)
 
-    while ((size <= availableFunds) && (count <= 1000)) {
+    while ((size <= availableFunds) && (count <= 1999)) {
       let actualSize = size;
 
       if (finalPrice >= tradingPrice) {
@@ -97,11 +97,11 @@ function AutoSetup(props) {
       <h4>Auto Setup</h4>
       <p>
         Enter the parameters you want and the bot will keep placing trades for you based on
-        those parameters until you run out of cash, or until you have 1000 trade-pairs.
+        those parameters until you run out of cash, or until you have 1999 trade-pairs.
         This is much easier than manually placing dozens of trades if they are following a basic pattern.
       </p>
       <p>
-        Please be aware that placing over 1000 trade-pairs will greatly slow down the bot and may decrease profits.
+        Please be aware that placing over 1999 trade-pairs will greatly slow down the bot and may decrease profits.
       </p>
 
       <div className="divider" />

--- a/src/components/Settings/AutoSetup/AutoSetup.js
+++ b/src/components/Settings/AutoSetup/AutoSetup.js
@@ -35,7 +35,7 @@ function AutoSetup(props) {
     let count = 0;
     setSetupResults(startingValue)
 
-    while ((size <= availableFunds) && (count <= 1999)) {
+    while ((size <= availableFunds) && (count < 1999)) {
       let actualSize = size;
 
       if (finalPrice >= tradingPrice) {

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -69,12 +69,6 @@ function Status(props) {
     <div className="Status boxed fit">
       {/* todo - maybe style in some divider lines here or something */}
       <p className="info status-ticker"><strong>~~~ BTC-USD ~~~</strong><br />${props.priceTicker}/coin</p>
-      {/* <p className="info status-ticker">${props.store.statusReducer.tickerReducer.tickerPrice}/coin</p> */}
-      {/* <p className="info status-ticker"><strong>~~~ Coinbot ~~~</strong></p> */}
-      {/* <p className="info status-ticker">{(localWebsocket) ? 'Local WS Connected' : 'Local WS Problem'}</p>
-      <p className="info status-ticker">{(cbWebsocket) ? 'CB WS Connected' : 'CB WS Problem'}</p>
-      <p className="info status-ticker">{(connection) ? 'Ticker Connected' : 'Ticker Problem'}</p> */}
-      {/* <p className="info status-ticker"><strong>~~~ Account ~~~</strong></p> */}
       <p className="info status-ticker"><strong>Available Funds</strong><br />${Math.floor(props.store.accountReducer.accountReducer * 100) / 100}</p>
       <p className="info status-ticker"><strong>Maker Fee</strong><br />{Number((props.store.accountReducer.feeReducer.maker_fee_rate * 100).toFixed(2))}%</p>
       <p className="info status-ticker"><strong>Taker Fee</strong><br />{Number((props.store.accountReducer.feeReducer.taker_fee_rate * 100).toFixed(2))}%</p>
@@ -82,8 +76,6 @@ function Status(props) {
       <p className="info status-ticker"><strong>Profit Estimate</strong><br />${Number(props.store.accountReducer.profitsReducer[0].sum)}</p>
       <p className="info status-ticker"><strong>Total Open Orders</strong><br />{openOrderQuantity}</p>
       <p className="info status-ticker">~~{loopStatus ? <strong>HEARTBEAT</strong> : <strong>heartbeat</strong>}~~</p>
-      {/* <p className="small">*Profit calculation is a work in progress, but this should be close</p> */}
-      {/* .store.accountReducer.feeReducer */}
     </div>
   )
 }

--- a/src/components/Trade/Trade.js
+++ b/src/components/Trade/Trade.js
@@ -226,7 +226,7 @@ function Trade(props) {
           <div className="number-inputs">
             {/* input for setting how much bitcoin should be traded per transaction at the specified price */}
             <label htmlFor="trade-pair-ratio">
-              Trade pair ratio (percent):
+              Trade pair percent increase:
             </label>
             <input
               className={props.store.accountReducer.userReducer.theme}


### PR DESCRIPTION
Enables the bot to pull more trades from Coinbase in each loop. It can now handle 1999 trades without slowing down significantly