### PR TITLE
Interface fixes

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS "user_settings"
   "reinvest_ratio" integer DEFAULT 0,
   "max_trade" boolean DEFAULT false,
   "max_trade_size" numeric(32,8) DEFAULT 0,
+  "max_trade_load" integer DEFAULT 1000,
   "profit_reset" timestamp
 );
 

--- a/server/modules/databaseClient.js
+++ b/server/modules/databaseClient.js
@@ -58,21 +58,25 @@ const getUnsettledTrades = (side, userID) => {
     // can request a limited amount of data to save on network costs
     if (side == 'buy') {
       // gets all unsettled buys, sorted by price
-      sqlText = `SELECT "id", price, size, trade_pair_ratio, side, product_id, created_at, original_buy_price, original_sell_price FROM "orders" WHERE "side"='buy' AND "flipped"=false AND "will_cancel"=false AND "userID"=$1
+      sqlText = `SELECT "id", price, size, trade_pair_ratio, side, product_id, created_at, original_buy_price, original_sell_price FROM "orders" 
+      WHERE "side"='buy' AND "flipped"=false AND "will_cancel"=false AND "userID"=$1
       ORDER BY "price" DESC;`;
+      // LIMIT 10;`;
       pool.query(sqlText, [userID])
-        .then((results) => {
-          // promise returns promise from pool if success
-          resolve(results.rows);
-        })
-        .catch((err) => {
-          // or promise relays errors from pool to parent
-          reject(err);
-        })
+      .then((results) => {
+        // promise returns promise from pool if success
+        resolve(results.rows);
+      })
+      .catch((err) => {
+        // or promise relays errors from pool to parent
+        reject(err);
+      })
     } else if (side == 'sell') {
       // gets all unsettled sells, sorted by price
-      sqlText = `SELECT "id", price, size, trade_pair_ratio, side, product_id, created_at, original_buy_price, original_sell_price FROM "orders" WHERE "side"='sell' AND "flipped"=false AND "will_cancel"=false AND "userID"=$1
+      sqlText = `SELECT "id", price, size, trade_pair_ratio, side, product_id, created_at, original_buy_price, original_sell_price FROM "orders" 
+      WHERE "side"='sell' AND "flipped"=false AND "will_cancel"=false AND "userID"=$1
       ORDER BY "price" DESC;`;
+      // LIMIT 10;`;
       pool.query(sqlText, [userID])
         .then((results) => {
           // promise returns promise from pool if success

--- a/server/modules/databaseClient.js
+++ b/server/modules/databaseClient.js
@@ -78,7 +78,7 @@ const getUnsettledTrades = (side, userID) => {
       // gets all unsettled sells, sorted by price
       sqlText = `SELECT "id", price, size, trade_pair_ratio, side, product_id, created_at, original_buy_price, original_sell_price FROM "orders" 
       WHERE "side"='sell' AND "flipped"=false AND "will_cancel"=false AND "userID"=$1
-      ORDER BY "price" DESC
+      ORDER BY "price" ASC
       LIMIT $2;`;
       pool.query(sqlText, [userID, userSettings.max_trade_load])
         .then((results) => {

--- a/server/modules/databaseClient.js
+++ b/server/modules/databaseClient.js
@@ -105,6 +105,40 @@ const getUnsettledTrades = (side, userID) => {
   });
 }
 
+const getUnsettledTradeCounts = (userID) => {
+  return new Promise(async (resolve, reject) => {
+    try {
+
+      // get total open orders
+      let sqlTextTotal = `SELECT COUNT(*) FROM "orders" WHERE "userID"=$1 AND settled=false;`;
+      let totalResult = await pool.query(sqlTextTotal, [userID]);
+      const totalOpenOrders = totalResult.rows[0];
+
+      // get total open buys
+      let sqlTextBuys = `SELECT COUNT(*) FROM "orders" WHERE "userID"=$1 AND settled=false AND side='buy';`;
+      let buysResult = await pool.query(sqlTextBuys, [userID]);
+      const totalOpenBuys = buysResult.rows[0];
+
+      // get total open sells
+      let sqlTextSells = `SELECT COUNT(*) FROM "orders" WHERE "userID"=$1 AND settled=false AND side='sell';`;
+      let sellsResult = await pool.query(sqlTextSells, [userID]);
+      const totalOpenSells = sellsResult.rows[0];
+
+      const unsettledOrderCounts = {
+        totalOpenOrders,
+        totalOpenBuys,
+        totalOpenSells
+      }
+
+      // promise returns promise from pool if success
+      resolve(unsettledOrderCounts);
+    } catch (err) {
+      // or promise relays errors from pool to parent
+      reject(err);
+    }
+  });
+}
+
 
 const getSingleTrade = (id) => {
   return new Promise((resolve, reject) => {
@@ -252,6 +286,7 @@ async function setPause(status, userID) {
 const databaseClient = {
   storeTrade: storeTrade,
   getUnsettledTrades: getUnsettledTrades,
+  getUnsettledTradeCounts: getUnsettledTradeCounts,
   getSingleTrade: getSingleTrade,
   deleteTrade: deleteTrade,
   getUser: getUser,

--- a/server/modules/databaseClient.js
+++ b/server/modules/databaseClient.js
@@ -58,7 +58,7 @@ const getUnsettledTrades = (side, userID) => {
     // the only time 'buy' or 'sell' is passed is when the frontend is calling for all trades. 
     // can request a limited amount of data to save on network costs
     if (side == 'buy') {
-      console.log('getting buys', userSettings.max_trade_load);
+      // console.log('getting buys', userSettings.max_trade_load);
       // gets all unsettled buys, sorted by price
       sqlText = `SELECT "id", price, size, trade_pair_ratio, side, product_id, created_at, original_buy_price, original_sell_price FROM "orders" 
       WHERE "side"='buy' AND "flipped"=false AND "will_cancel"=false AND "userID"=$1
@@ -74,7 +74,7 @@ const getUnsettledTrades = (side, userID) => {
         reject(err);
       })
     } else if (side == 'sell') {
-      console.log('getting sells', userSettings.max_trade_load);
+      // console.log('getting sells', userSettings.max_trade_load);
       // gets all unsettled sells, sorted by price
       sqlText = `SELECT "id", price, size, trade_pair_ratio, side, product_id, created_at, original_buy_price, original_sell_price FROM "orders" 
       WHERE "side"='sell' AND "flipped"=false AND "will_cancel"=false AND "userID"=$1

--- a/server/modules/robot.js
+++ b/server/modules/robot.js
@@ -599,18 +599,16 @@ async function autoSetup(user, parameters) {
     return;
   }
 
-  console.log("autoSetup parameters", parameters);
+  // console.log("autoSetup parameters", parameters);
 
   // assume size is in btc
   let convertedAmount = parameters.size;
 
   // if size is in usd, convert it to btc
   if (parameters.sizeType === "USD") {
-    console.log('need to convert to btc!');
+    // console.log('need to convert to btc!');
     // get the BTC size from the entered USD size
     convertedAmount = Number(Math.floor((parameters.size / parameters.startingValue) * 100000000)) / 100000000;
-  } else {
-    console.log('no need to convert to btc');
   }
     // console.log(convertedAmount);
 

--- a/server/modules/robot.js
+++ b/server/modules/robot.js
@@ -644,7 +644,7 @@ async function autoSetup(user, parameters) {
 
     // create new parameters 
 
-    const newStartingValue = (Number(parameters.startingValue) + Number(parameters.increment));
+    const newStartingValue = (Number(parameters.startingValue) + Number(parameters.increment)).toFixed(2);
 
     const newParameters = {
       startingValue: newStartingValue, // done

--- a/server/routes/orders.router.js
+++ b/server/routes/orders.router.js
@@ -20,18 +20,21 @@ router.get('/', rejectUnauthenticated, (req, res) => {
     // get all open orders from db and from coinbase
     databaseClient.getUnsettledTrades('buy', userID),
     databaseClient.getUnsettledTrades('sell', userID),
+    databaseClient.getUnsettledTradeCounts(userID)
   ])
     .then((result) => {
-      const buys = result[0], sells = result[1];
+      const buys = result[0], sells = result[1], counts = result[2];
       const openOrdersInOrder = {
         sells: sells,
-        buys: buys
+        buys: buys,
+        counts: counts
       }
       // console.log('here are all the open orders', openOrdersInOrder);
       res.send(openOrdersInOrder)
     })
     .catch((error) => {
-      res.send(500)
+      console.log(error, 'error in get orders route');
+      res.sendStatus(500)
     })
 });
 

--- a/server/routes/orders.router.js
+++ b/server/routes/orders.router.js
@@ -96,7 +96,7 @@ router.delete('/', rejectUnauthenticated, async (req, res) => {
     
     // set pause status to what it was before route was hit
     await databaseClient.setPause(previousPauseStatus, userID)
-    // console.log('+++++++ EVERYTHING WAS DELETED +++++++');
+    console.log('+++++++ EVERYTHING WAS DELETED +++++++ for user:', userID);
     // tell front end to update
     socketClient.emit('message', {
       orderUpdate: true

--- a/server/routes/settings.router.js
+++ b/server/routes/settings.router.js
@@ -83,6 +83,27 @@ router.put('/toggleMaintenance', rejectUnauthenticated, async (req, res) => {
 });
 
 /**
+ * PUT route setting Trade Load Max
+ */
+router.put('/tradeLoadMax', rejectUnauthenticated, async (req, res) => {
+  // POST route code here
+  const user = req.user;
+  console.log('toggleMaintenance route hit!');
+  try {
+    console.log('tradeLoadMax route hit!', user, req.body);
+
+    const queryText = `UPDATE "user_settings" SET "max_trade_load" = $1 WHERE "userID" = $2`;
+    await pool.query(queryText, [req.body.max_trade_load, user.id]);
+
+    res.sendStatus(200);
+  } catch (err) {
+    console.log('error with toggleMaintenance route', err);
+    res.sendStatus(500);
+  }
+
+});
+
+/**
  * PUT route bulk updating trade pair ratio
  */
 router.put('/bulkPairRatio', rejectUnauthenticated, async (req, res) => {
@@ -122,16 +143,16 @@ router.put('/bulkPairRatio', rejectUnauthenticated, async (req, res) => {
     // Now cancel all trades so they can be reordered with the new numbers
     // pause trading before cancelling all orders or it will reorder them before done, making it take longer
     await databaseClient.setPause(true, userID)
-    
+
     // wait 5 seconds to give the synch loop more time to finish
     await robot.sleep(5000);
-    
+
     // mark all open orders as reorder
     await databaseClient.setReorder();
 
     // cancel all orders. The sync loop will take care of replacing them
     await coinbaseClient.cancelAllOrders(userID);
-    
+
     // set pause status to what it was before route was hit
     await databaseClient.setPause(previousPauseStatus, userID)
 

--- a/src/components/Settings/AutoSetup/AutoSetup.js
+++ b/src/components/Settings/AutoSetup/AutoSetup.js
@@ -193,7 +193,7 @@ function AutoSetup(props) {
             The price of the last trade-pair will be close to:
           </p>
           <p>
-            <strong>{numberWithCommas(setupResults)}</strong>
+            <strong>{numberWithCommas(setupResults.toFixed(2))}</strong>
           </p>
           <p>
             This calculation isn't perfect but it will get close. It can also change if the price of BTC moves up or down significantly while the

--- a/src/components/Settings/General/General.js
+++ b/src/components/Settings/General/General.js
@@ -83,7 +83,7 @@ function General(props) {
           </p>
           {props.store.accountReducer.userReducer.max_trade &&
             <>
-              <p>Current max trades to load per side: {Number(props.store.accountReducer.userReducer.max_trade_size)}</p>
+              <p>Current max trades to load per side: {Number(props.store.accountReducer.userReducer.max_trade_load)}</p>
               <label htmlFor="reinvest_ratio">
                 Set Max:
               </label>

--- a/src/components/Settings/General/General.js
+++ b/src/components/Settings/General/General.js
@@ -7,6 +7,8 @@ import './General.css'
 function General(props) {
   const dispatch = useDispatch();
 
+  const [max_trade_load, setMaxTradeLoad] = useState(100);
+
 
   function pause(event) {
     // event.preventDefault();
@@ -23,6 +25,17 @@ function General(props) {
       type: 'SET_THEME',
       payload: {
         theme: theme
+      }
+    });
+  }
+  
+  function sendTradeLoadMax(event) {
+    // event.preventDefault();
+    console.log('tradeLoadMax sent!');
+    dispatch({
+      type: 'SET_MAX_TRADE_LOAD',
+      payload: {
+        max_trade_load: max_trade_load
       }
     });
   }
@@ -52,6 +65,42 @@ function General(props) {
         : <button className={`btn-blue medium ${props.theme}`} onClick={() => { pause() }}>Pause</button>
       }
       <div className="divider" />
+
+      {/* MAX TRADES ON SCREEN */}
+      {
+        props.store.accountReducer.userReducer.reinvest &&
+        <>
+          <h4>Max Trades on Screen</h4>
+          <p>
+            Limit the number of trades to load per side (buy/sell). This can make load times shorter and limit the amount of scrolling
+            needed to get to the split. 
+            <br/>
+            <br/>
+            Since it is PER SIDE, setting the value to 10 for example would potentially load up to 20 trades total.
+            <br/>
+            <br/>
+            There is a hard limit of 10,000 open trades per user, so there is no reason to set the value higher than that.
+          </p>
+          {props.store.accountReducer.userReducer.max_trade &&
+            <>
+              <p>Current max trades to load per side: {Number(props.store.accountReducer.userReducer.max_trade_size)}</p>
+              <label htmlFor="reinvest_ratio">
+                Set Max:
+              </label>
+              <input
+                type="number"
+                name="reinvest_ratio"
+                value={max_trade_load}
+                required
+                onChange={(event) => setMaxTradeLoad(Number(event.target.value))}
+              />
+              <br />
+              <button className={`btn-blue btn-reinvest medium ${props.theme}`} onClick={(event) => { sendTradeLoadMax(event) }}>Save Max</button>
+              <div className="divider" />
+            </>
+          }
+        </>
+      }
     </div>
   );
 }

--- a/src/components/Settings/General/General.js
+++ b/src/components/Settings/General/General.js
@@ -7,82 +7,12 @@ import './General.css'
 function General(props) {
   const dispatch = useDispatch();
 
-  const [reinvest_ratio, setReinvest_ratio] = useState(0);
-  const [bulk_pair_ratio, setBulk_pair_ratio] = useState(1.1);
-  const [max_trade_size, setMaxTradeSize] = useState(30);
-
-  // make sure ratio is within percentage range
-  useEffect(() => {
-    // if (reinvest_ratio > 500) {
-    //   setReinvest_ratio(500)
-    // }
-    if (reinvest_ratio < 0) {
-      setReinvest_ratio(0)
-    }
-  }, [reinvest_ratio]);
-
-  useEffect(() => {
-    setReinvest_ratio(props.store.accountReducer.userReducer.reinvest_ratio)
-  }, [props.store.accountReducer.userReducer.reinvest_ratio])
-
-  useEffect(() => {
-    setMaxTradeSize(Number(props.store.accountReducer.userReducer.max_trade_size))
-  }, [props.store.accountReducer.userReducer.max_trade_size])
 
   function pause(event) {
     // event.preventDefault();
     console.log('Pausing the bot!');
     dispatch({
       type: 'PAUSE',
-    });
-  }
-
-  function reinvest(event) {
-    // event.preventDefault();
-    console.log('reinvest sent!');
-    dispatch({
-      type: 'REINVEST',
-    });
-  }
-
-  function reinvestRatio(event) {
-    event.preventDefault();
-    console.log('reinvest ratio submitted!');
-    dispatch({
-      type: 'REINVEST_RATIO',
-      payload: {
-        reinvest_ratio: reinvest_ratio
-      }
-    });
-  }
-
-  function tradeMax(event) {
-    // event.preventDefault();
-    console.log('toggle trade max sent!');
-    dispatch({
-      type: 'TOGGLE_TRADE_MAX',
-    });
-  }
-
-  function storeMaxTradeSize(event) {
-    event.preventDefault();
-    console.log('reinvest ratio submitted!');
-    dispatch({
-      type: 'STORE_MAX_TRADE_SIZE',
-      payload: {
-        max_trade_size: max_trade_size
-      }
-    });
-  }
-
-  function bulkPairRatio(event) {
-    event.preventDefault();
-    console.log('bulk ratio sent!');
-    dispatch({
-      type: 'SET_BULK_PAIR_RATIO',
-      payload: {
-        bulk_pair_ratio: bulk_pair_ratio
-      }
     });
   }
 
@@ -96,7 +26,6 @@ function General(props) {
       }
     });
   }
-
 
 
   return (
@@ -123,103 +52,6 @@ function General(props) {
         : <button className={`btn-blue medium ${props.theme}`} onClick={() => { pause() }}>Pause</button>
       }
       <div className="divider" />
-
-      {/* REINVEST */}
-      <h4>Reinvestment</h4>
-      <p>Coinbot can try to reinvest your profits for you. Be aware that this may not
-        work if the profit is too small.
-      </p>
-      {(props.store.accountReducer.userReducer.reinvest)
-        ? <button className={`btn-blue medium ${props.theme}`} onClick={() => { reinvest() }}>Turn off</button>
-        : <button className={`btn-blue medium ${props.theme}`} onClick={() => { reinvest() }}>Turn on</button>
-      }
-      {props.store.accountReducer.userReducer.reinvest &&
-        <>
-        {((reinvest_ratio > 100) || (props.store.accountReducer.userReducer.reinvest_ratio > 100)) && 
-        <p>** WARNING! ** <br/> Setting the reinvestment ratio higher than 100% will take money from your available funds! 
-        You will need to keep an eye on the bot and make sure you don't run out!</p>
-        }
-          <p>Current reinvestment ratio: {props.store.accountReducer.userReducer.reinvest_ratio}%</p>
-          <label htmlFor="reinvest_ratio">
-            Set Ratio:
-          </label>
-          <input
-            type="number"
-            name="reinvest_ratio"
-            value={reinvest_ratio}
-            step={10}
-            // max={200}
-            required
-            onChange={(event) => setReinvest_ratio(event.target.value)}
-          />
-          <br />
-          <button className={`btn-blue btn-reinvest medium ${props.theme}`} onClick={(event) => { reinvestRatio(event) }}>Save reinvestment ratio</button>
-          <div className="divider" />
-        </>
-      }
-
-      {/* MAX TRADE SIZE USD */}
-      {/* only show if reinvest is also turned on */}
-      {
-        props.store.accountReducer.userReducer.reinvest &&
-        <>
-          <h4>Max Trade Size</h4>
-          <p>
-            Coinbot can try to limit the size of your trades. This is useful in case you want to
-            stop reinvesting after a certain point, but keep reinvestment turned on for all other trades.
-            Size cap is in USD. If set to 0, the bot will ignore it and default to the reinvestment ratio.
-          </p>
-          {(props.store.accountReducer.userReducer.max_trade)
-            ? <button className={`btn-blue medium ${props.theme}`} onClick={() => { tradeMax() }}>Turn off</button>
-            : <button className={`btn-blue medium ${props.theme}`} onClick={() => { tradeMax() }}>Turn on</button>
-          }
-          {props.store.accountReducer.userReducer.max_trade &&
-            <>
-              <p>Current max trade size: ${Number(props.store.accountReducer.userReducer.max_trade_size)}</p>
-              <label htmlFor="reinvest_ratio">
-                Set Max:
-              </label>
-              <input
-                type="number"
-                name="reinvest_ratio"
-                value={max_trade_size}
-                // step={10}
-                // max={200}
-                required
-                onChange={(event) => setMaxTradeSize(Number(event.target.value))}
-              />
-              <br />
-              <button className={`btn-blue btn-reinvest medium ${props.theme}`} onClick={(event) => { storeMaxTradeSize(event) }}>Save Max</button>
-              <div className="divider" />
-            </>
-          }
-        </>
-      }
-
-      {/* BULK PERCENTAGE CHANGE */}
-      <h4>Bulk Percentage Change</h4>
-      <p>
-        EXPERIMENTAL FEATURE. This will change the trade pair ratio for ALL trades to a uniform percentage. This can be useful for when your fees change due to trade volume and you want to change the ratio accordingly.
-      </p>
-      <>
-        <label htmlFor="bulk_pair_ratio">
-          New Ratio:
-        </label>
-        <input
-          type="number"
-          name="bulk_pair_ratio"
-          value={bulk_pair_ratio}
-          step={.1}
-          max={100}
-          min={0}
-          required
-          onChange={(event) => setBulk_pair_ratio(Number(event.target.value))}
-        />
-        <br />
-        <button className={`btn-blue btn-bulk-pair-ratio medium ${props.theme}`} onClick={(event) => { bulkPairRatio(event) }}>Set all trades to new ratio</button>
-        <div className="divider" />
-      </>
-
     </div>
   );
 }

--- a/src/components/Settings/Investment/Investment.css
+++ b/src/components/Settings/Investment/Investment.css
@@ -1,0 +1,7 @@
+.Investment{
+  height: 60vh;
+}
+
+.btn-reinvest{
+  margin: .2rem auto;
+}

--- a/src/components/Settings/Investment/Investment.js
+++ b/src/components/Settings/Investment/Investment.js
@@ -1,0 +1,186 @@
+import React, { useState, useEffect } from 'react';
+import { connect, useDispatch } from 'react-redux';
+import mapStoreToProps from '../../../redux/mapStoreToProps';
+import './Investment.css'
+
+
+function Investment(props) {
+  const dispatch = useDispatch();
+
+  const [reinvest_ratio, setReinvest_ratio] = useState(0);
+  const [bulk_pair_ratio, setBulk_pair_ratio] = useState(1.1);
+  const [max_trade_size, setMaxTradeSize] = useState(30);
+
+  // make sure ratio is within percentage range
+  useEffect(() => {
+    // if (reinvest_ratio > 500) {
+    //   setReinvest_ratio(500)
+    // }
+    if (reinvest_ratio < 0) {
+      setReinvest_ratio(0)
+    }
+  }, [reinvest_ratio]);
+
+  useEffect(() => {
+    setReinvest_ratio(props.store.accountReducer.userReducer.reinvest_ratio)
+  }, [props.store.accountReducer.userReducer.reinvest_ratio])
+
+  useEffect(() => {
+    setMaxTradeSize(Number(props.store.accountReducer.userReducer.max_trade_size))
+  }, [props.store.accountReducer.userReducer.max_trade_size])
+
+  function reinvest(event) {
+    // event.preventDefault();
+    console.log('reinvest sent!');
+    dispatch({
+      type: 'REINVEST',
+    });
+  }
+
+  function reinvestRatio(event) {
+    event.preventDefault();
+    console.log('reinvest ratio submitted!');
+    dispatch({
+      type: 'REINVEST_RATIO',
+      payload: {
+        reinvest_ratio: reinvest_ratio
+      }
+    });
+  }
+
+  function tradeMax(event) {
+    // event.preventDefault();
+    console.log('toggle trade max sent!');
+    dispatch({
+      type: 'TOGGLE_TRADE_MAX',
+    });
+  }
+
+  function storeMaxTradeSize(event) {
+    event.preventDefault();
+    console.log('reinvest ratio submitted!');
+    dispatch({
+      type: 'STORE_MAX_TRADE_SIZE',
+      payload: {
+        max_trade_size: max_trade_size
+      }
+    });
+  }
+
+  function bulkPairRatio(event) {
+    event.preventDefault();
+    console.log('bulk ratio sent!');
+    dispatch({
+      type: 'SET_BULK_PAIR_RATIO',
+      payload: {
+        bulk_pair_ratio: bulk_pair_ratio
+      }
+    });
+  }
+
+
+  return (
+    <div className="Investment scrollable">
+      <div className="divider" />
+
+      {/* REINVEST */}
+      <h4>Reinvestment</h4>
+      <p>Coinbot can try to reinvest your profits for you. Be aware that this may not
+        work if the profit is too small.
+      </p>
+      {(props.store.accountReducer.userReducer.reinvest)
+        ? <button className={`btn-blue medium ${props.theme}`} onClick={() => { reinvest() }}>Turn off</button>
+        : <button className={`btn-blue medium ${props.theme}`} onClick={() => { reinvest() }}>Turn on</button>
+      }
+      {props.store.accountReducer.userReducer.reinvest &&
+        <>
+          {((reinvest_ratio > 100) || (props.store.accountReducer.userReducer.reinvest_ratio > 100)) &&
+            <p>** WARNING! ** <br /> Setting the reinvestment ratio higher than 100% will take money from your available funds!
+              You will need to keep an eye on the bot and make sure you don't run out!</p>
+          }
+          <p>Current reinvestment ratio: {props.store.accountReducer.userReducer.reinvest_ratio}%</p>
+          <label htmlFor="reinvest_ratio">
+            Set Ratio:
+          </label>
+          <input
+            type="number"
+            name="reinvest_ratio"
+            value={reinvest_ratio}
+            step={10}
+            // max={200}
+            required
+            onChange={(event) => setReinvest_ratio(event.target.value)}
+          />
+          <br />
+          <button className={`btn-blue btn-reinvest medium ${props.theme}`} onClick={(event) => { reinvestRatio(event) }}>Save reinvestment ratio</button>
+          <div className="divider" />
+        </>
+      }
+
+      {/* MAX TRADE SIZE USD */}
+      {/* only show if reinvest is also turned on */}
+      {
+        props.store.accountReducer.userReducer.reinvest &&
+        <>
+          <h4>Max Trade Size</h4>
+          <p>
+            Coinbot can try to limit the size of your trades. This is useful in case you want to
+            stop reinvesting after a certain point, but keep reinvestment turned on for all other trades.
+            Size cap is in USD. If set to 0, the bot will ignore it and default to the reinvestment ratio.
+          </p>
+          {(props.store.accountReducer.userReducer.max_trade)
+            ? <button className={`btn-blue medium ${props.theme}`} onClick={() => { tradeMax() }}>Turn off</button>
+            : <button className={`btn-blue medium ${props.theme}`} onClick={() => { tradeMax() }}>Turn on</button>
+          }
+          {props.store.accountReducer.userReducer.max_trade &&
+            <>
+              <p>Current max trade size: ${Number(props.store.accountReducer.userReducer.max_trade_size)}</p>
+              <label htmlFor="reinvest_ratio">
+                Set Max:
+              </label>
+              <input
+                type="number"
+                name="reinvest_ratio"
+                value={max_trade_size}
+                // step={10}
+                // max={200}
+                required
+                onChange={(event) => setMaxTradeSize(Number(event.target.value))}
+              />
+              <br />
+              <button className={`btn-blue btn-reinvest medium ${props.theme}`} onClick={(event) => { storeMaxTradeSize(event) }}>Save Max</button>
+              <div className="divider" />
+            </>
+          }
+        </>
+      }
+
+      {/* BULK PERCENTAGE CHANGE */}
+      <h4>Bulk Percentage Change</h4>
+      <p>
+        EXPERIMENTAL FEATURE. This will change the trade pair ratio for ALL trades to a uniform percentage. This can be useful for when your fees change due to trade volume and you want to change the ratio accordingly.
+      </p>
+      <>
+        <label htmlFor="bulk_pair_ratio">
+          New Ratio:
+        </label>
+        <input
+          type="number"
+          name="bulk_pair_ratio"
+          value={bulk_pair_ratio}
+          step={.1}
+          max={100}
+          min={0}
+          required
+          onChange={(event) => setBulk_pair_ratio(Number(event.target.value))}
+        />
+        <br />
+        <button className={`btn-blue btn-bulk-pair-ratio medium ${props.theme}`} onClick={(event) => { bulkPairRatio(event) }}>Set all trades to new ratio</button>
+        <div className="divider" />
+      </>
+
+    </div>
+  );
+}
+
+export default connect(mapStoreToProps)(Investment);

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -4,6 +4,7 @@ import mapStoreToProps from '../../redux/mapStoreToProps';
 import Admin from './Admin/Admin';
 import AutoSetup from './AutoSetup/AutoSetup';
 import General from './General/General';
+import Investment from './Investment/Investment';
 import Reset from './Reset/Reset';
 import History from './History/History';
 import './Settings.css'
@@ -23,6 +24,7 @@ function Settings(props) {
         {
           {
             'general': <General theme={props.theme} />,
+            'investment': <Investment theme={props.theme} />,
             'history': <History theme={props.theme} />,
             'autoSetup': <AutoSetup theme={props.theme} priceTicker={props.priceTicker} />,
             'reset': <Reset theme={props.theme} />,

--- a/src/components/Settings/SettingsNav/SettingsNav.js
+++ b/src/components/Settings/SettingsNav/SettingsNav.js
@@ -10,6 +10,7 @@ function SettingsNav(props) {
     <div className="SettingsNav">
       <center>
         <button className = {`btn-nav ${props.settingsPage === "general" && "selected"}`} onClick={() => { props.setSettingsPage('general') }}>General</button>
+        <button className = {`btn-nav ${props.settingsPage === "investment" && "selected"}`} onClick={() => { props.setSettingsPage('investment') }}>Investment</button>
         <button className={`btn-nav ${props.settingsPage === "autoSetup" && "selected"}`} onClick={() => { props.setSettingsPage('autoSetup') }}>Auto Setup</button>
         <button className={`btn-nav ${props.settingsPage === "reset" && "selected"}`} onClick={() => { props.setSettingsPage('reset') }}>Reset</button>
         <button className={`btn-nav ${props.settingsPage === "history" && "selected"}`} onClick={() => { props.setSettingsPage('history') }}>History</button>

--- a/src/components/SingleTrade/SingleTrade.js
+++ b/src/components/SingleTrade/SingleTrade.js
@@ -95,7 +95,7 @@ function SingleTrade(props) {
           }
           {/* {JSON.stringify(props.order)} */}
           {
-            showAll && !deleting && <><strong> Pair Ratio:</strong> {Number(props.order.trade_pair_ratio)}</>
+            showAll && !deleting && <><strong> Pair Ratio:</strong> {Number(props.order.trade_pair_ratio)}%</>
           }
           {
             showAll && !deleting && <><strong> Buy Fees:</strong> {buyFee.toFixed(8)}</>

--- a/src/components/SingleTrade/SingleTrade.js
+++ b/src/components/SingleTrade/SingleTrade.js
@@ -58,14 +58,20 @@ function SingleTrade(props) {
   // postgres is much better at math using exact
 
   return (
-    <div className={`Single-trade ${props.order.side} ${props.store.accountReducer.userReducer.theme}`}>
+    <div className={`Single-trade ${props.order.side} ${props.theme}`}>
       <div className={"overlay"}>
         {(deleting === true)
           ? <p className="deleting">Deleting...</p>
-          : <button className={`btn-red ${props.store.accountReducer.userReducer.theme}`} onClick={() => { deleteOrder() }}>Abandon</button>
+          : <>
+            <button className={`btn-red ${props.theme}`} onClick={() => { deleteOrder() }}>Kill</button>
+            {showAll
+              ? <button className={`btn-blue ${props.theme}`} onClick={toggleShowAll}>&#9650;</button>
+              : <button className={`btn-blue ${props.theme}`} onClick={toggleShowAll}>&#9660;</button>
+            }
+          </>
         }
-        <p className="single-trade-text" onClick={toggleShowAll}>
-          {/* {JSON.stringify(props.store.accountReducer.userReducer.theme)} */}
+        <p className="single-trade-text" >
+          {/* {JSON.stringify(props.theme)} */}
           <strong>
             Price: </strong>
           {(props.order.side === 'sell')
@@ -91,13 +97,13 @@ function SingleTrade(props) {
             showAll && !deleting && <><strong> Buy Fees:</strong> {buyFee.toFixed(8)}</>
           }
           {
-          showAll && !deleting && <><strong> Sell Fees:</strong> {sellFee.toFixed(8)}</>
+            showAll && !deleting && <><strong> Sell Fees:</strong> {sellFee.toFixed(8)}</>
           }
           {
-          showAll && !deleting && <><strong> Total Fees:</strong> {(Number(sellFee.toFixed(8)) + Number(buyFee.toFixed(8))).toFixed(8)}</>
+            showAll && !deleting && <><strong> Total Fees:</strong> {(Number(sellFee.toFixed(8)) + Number(buyFee.toFixed(8))).toFixed(8)}</>
           }
           {
-          showAll && !deleting && <><strong> Gross Pair Profit:</strong> {(props.order.original_sell_price * props.order.size - props.order.original_buy_price * props.order.size).toFixed(8)}</>
+            showAll && !deleting && <><strong> Gross Pair Profit:</strong> {(props.order.original_sell_price * props.order.size - props.order.original_buy_price * props.order.size).toFixed(8)}</>
           }
         </p>
       </div>

--- a/src/components/SingleTrade/SingleTrade.js
+++ b/src/components/SingleTrade/SingleTrade.js
@@ -89,6 +89,10 @@ function SingleTrade(props) {
           <strong>Value</strong> ${numberWithCommas((Math.round((props.order.price * props.order.size) * 100) / 100).toFixed(2))} ~
           <strong>Pair Profit</strong> ${profit.toFixed(8)}
           <strong> ~Time</strong> {new Date(props.order.created_at).toLocaleString('en-US')}
+          <br />
+          {
+            showAll && !deleting && <><strong> Pair Ratio:</strong> {Number(props.order.trade_pair_ratio)}</>
+          }
           {/* {JSON.stringify(props.order)} */}
           {
             showAll && !deleting && <><strong> Pair Ratio:</strong> {Number(props.order.trade_pair_ratio)}</>

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -76,11 +76,11 @@ function Status(props) {
   // get the total number of open orders
   useEffect(() => {
     if (props.store.ordersReducer.openOrdersInOrder.sells !== undefined && props.store.ordersReducer.openOrdersInOrder.buys !== undefined) {
-      setOpenOrderQuantity(props.store.ordersReducer.openOrdersInOrder.sells.length + props.store.ordersReducer.openOrdersInOrder.buys.length)
-      setOpenSellsQuantity(props.store.ordersReducer.openOrdersInOrder.sells.length)
-      setOpenBuysQuantity(props.store.ordersReducer.openOrdersInOrder.buys.length)
+      setOpenOrderQuantity(props.store.ordersReducer.openOrdersInOrder.counts.totalOpenOrders.count)
+      setOpenSellsQuantity(props.store.ordersReducer.openOrdersInOrder.counts.totalOpenSells.count)
+      setOpenBuysQuantity(props.store.ordersReducer.openOrdersInOrder.counts.totalOpenBuys.count)
     }
-  }, [props.store.ordersReducer.openOrdersInOrder.sells, props.store.ordersReducer.openOrdersInOrder.buys]);
+  }, [props.store.ordersReducer.openOrdersInOrder.counts]);
 
 
   return (

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -8,6 +8,8 @@ import { useSocket } from "../../contexts/SocketProvider";
 function Status(props) {
   const dispatch = useDispatch();
   const [loopStatus, setLoopStatus] = useState(true);
+  const [openSellsQuantity, setOpenSellsQuantity] = useState(0);
+  const [openBuysQuantity, setOpenBuysQuantity] = useState(0);
   const [openOrderQuantity, setOpenOrderQuantity] = useState(0);
 
   const socket = useSocket();
@@ -75,6 +77,8 @@ function Status(props) {
   useEffect(() => {
     if (props.store.ordersReducer.openOrdersInOrder.sells !== undefined && props.store.ordersReducer.openOrdersInOrder.buys !== undefined) {
       setOpenOrderQuantity(props.store.ordersReducer.openOrdersInOrder.sells.length + props.store.ordersReducer.openOrdersInOrder.buys.length)
+      setOpenSellsQuantity(props.store.ordersReducer.openOrdersInOrder.sells.length)
+      setOpenBuysQuantity(props.store.ordersReducer.openOrdersInOrder.buys.length)
     }
   }, [props.store.ordersReducer.openOrdersInOrder.sells, props.store.ordersReducer.openOrdersInOrder.buys]);
 
@@ -124,7 +128,7 @@ function Status(props) {
       <p className="info status-ticker">
         <strong>Total Open Orders</strong>
         <br />
-        {numberWithCommas(openOrderQuantity)}
+        <strong>B:</strong>{numberWithCommas(openBuysQuantity)} <strong>S:</strong>{numberWithCommas(openSellsQuantity)} <strong>T:</strong>{numberWithCommas(openOrderQuantity)}
       </p>
 
       <p className="info status-ticker">~~{loopStatus ? <strong>HEARTBEAT</strong> : <strong>heartbeat</strong>}~~

--- a/src/components/TradeList/TradeList.js
+++ b/src/components/TradeList/TradeList.js
@@ -36,7 +36,7 @@ function TradeList(props) {
   // this watches the store and maps arrays to html when it changes because can't map nothing
   useEffect(() => {
     if (props.store.ordersReducer.openOrdersInOrder.sells !== undefined) {
-      setSells(props.store.ordersReducer.openOrdersInOrder.sells.map((sell) => {
+      setSells(props.store.ordersReducer.openOrdersInOrder.sells.reverse().map((sell) => {
         return <SingleTrade key={sell.id} order={sell} theme={props.theme} />
       }))
     }

--- a/src/components/TradeList/TradeList.js
+++ b/src/components/TradeList/TradeList.js
@@ -37,12 +37,12 @@ function TradeList(props) {
   useEffect(() => {
     if (props.store.ordersReducer.openOrdersInOrder.sells !== undefined) {
       setSells(props.store.ordersReducer.openOrdersInOrder.sells.map((sell) => {
-        return <SingleTrade key={sell.id} order={sell} />
+        return <SingleTrade key={sell.id} order={sell} theme={props.theme} />
       }))
     }
     if (props.store.ordersReducer.openOrdersInOrder.buys !== undefined) {
       setBuys(props.store.ordersReducer.openOrdersInOrder.buys.map((sell) => {
-        return <SingleTrade key={sell.id} order={sell} />
+        return <SingleTrade key={sell.id} order={sell} theme={props.theme} />
       }))
     }
   }, [props.store.ordersReducer.openOrdersInOrder.sells, props.store.ordersReducer.openOrdersInOrder.buys]);

--- a/src/redux/sagas/settings.saga.js
+++ b/src/redux/sagas/settings.saga.js
@@ -59,11 +59,26 @@ function* bulkPairRatio(action) {
   }
 }
 
+function* sendTradeLoadMax(action) {
+  try {
+    console.log('bulk setting pair ratio saga', action.payload);
+    const response = yield axios.put(`/api/settings/tradeLoadMax`, action.payload);
+    console.log('response from sendTradeLoadMax', response);
+    yield put({ type: 'FETCH_ORDERS' })
+  } catch (error) {
+    console.log('sendTradeLoadMax saga has failed', error);
+    if (error.response.status === 403) {
+      yield put({ type: 'UNSET_USER' });
+    }
+  }
+}
+
 
 function* settingsSaga() {
   yield takeLatest('FETCH_SETTINGS', getAllSettings);
   yield takeLatest('SEND_LOOP_SPEED', loopSpeed);
   yield takeLatest('SET_BULK_PAIR_RATIO', bulkPairRatio);
+  yield takeLatest('SET_MAX_TRADE_LOAD', sendTradeLoadMax);
   yield takeLatest('TOGGLE_MAINTENANCE', toggleMaintenance);
 }
 

--- a/src/redux/sagas/settings.saga.js
+++ b/src/redux/sagas/settings.saga.js
@@ -65,6 +65,7 @@ function* sendTradeLoadMax(action) {
     const response = yield axios.put(`/api/settings/tradeLoadMax`, action.payload);
     console.log('response from sendTradeLoadMax', response);
     yield put({ type: 'FETCH_ORDERS' })
+    yield put({ type: 'FETCH_USER' })
   } catch (error) {
     console.log('sendTradeLoadMax saga has failed', error);
     if (error.response.status === 403) {


### PR DESCRIPTION
Makes a bunch of small improvements to the user interface.

- User can decide how many trades per side to load. This will help with network usage and amount of scrolling to do when there are many trades placed
- Added a button to expand the trade details instead of clicking on it. It was impossible to copy/paste info because selecting it would make it disappear
- Added an Investment tab to the settings
- display the number of open buys and sells in addition to total open orders