### PR TITLE
Mobile nav

### DIFF
--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -27,15 +27,16 @@
 
 @media (max-width: 800px) {
   .Home {
-    display              : grid;
+    /* display              : grid; */
     /* this is STRICTLY A BUSINESS ROBOT, and the color should reflect that! */
-    grid-template-columns: auto auto;
-    gap                  : .4rem;
-    /* grid-template-rows   : auto min-content 1fr; */
-    /* height               : 100vh; */
+    grid-template-columns: 0fr auto 0fr;
+    grid-template-rows   : min-content min-content min-content min-content;
+    /* gap                  : .4rem; */
+    /* grid-template-rows   : unset; */
+    height               : 100vh;
   }
 
-  .header {
+  /* .header {
     grid-column     : 1/5;
     grid-row        : 1;
     background-color: #803535;
@@ -43,5 +44,5 @@
     align-items     : center;
     font-size       : calc(9px + 2vmin);
     color           : white;
-  }
+  } */
 }

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -13,9 +13,12 @@ import NotActive from '../NotActive/NotActive.js';
 import { SocketProvider } from '../../contexts/SocketProvider.js';
 import axios from 'axios';
 import MobileNav from '../MobileNav/MobileNav.js';
+import useWindowDimensions from '../../hooks/useWindowDimensions.js';
 
 function Home(props) {
   const dispatch = useDispatch();
+  const { height, width } = useWindowDimensions();
+
   const [showSettings, setShowSettings] = useState(false);
   const [theme, setTheme] = useState('original');
   const [priceTicker, setPriceTicker] = useState(0);
@@ -78,7 +81,7 @@ function Home(props) {
         <Updates theme={theme} />
         <Status theme={theme} priceTicker={priceTicker} />
         <Settings showSettings={showSettings} clickSettings={clickSettings} theme={theme} priceTicker={priceTicker} />
-        <MobileNav theme={theme} />
+        {width < 800 && <MobileNav theme={theme} />}
       </SocketProvider>
     </div>
   );

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -12,7 +12,7 @@ import NotApproved from '../NotApproved/NotApproved.js';
 import NotActive from '../NotActive/NotActive.js';
 import { SocketProvider } from '../../contexts/SocketProvider.js';
 import axios from 'axios';
-
+import MobileNav from '../MobileNav/MobileNav.js';
 
 function Home(props) {
   const dispatch = useDispatch();
@@ -78,6 +78,7 @@ function Home(props) {
         <Updates theme={theme} />
         <Status theme={theme} priceTicker={priceTicker} />
         <Settings showSettings={showSettings} clickSettings={clickSettings} theme={theme} priceTicker={priceTicker} />
+        <MobileNav theme={theme} />
       </SocketProvider>
     </div>
   );

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -21,6 +21,7 @@ function Home(props) {
 
   const [showSettings, setShowSettings] = useState(false);
   const [theme, setTheme] = useState('original');
+  const [mobilePage, setMobilePage] = useState('tradeList');
   const [priceTicker, setPriceTicker] = useState(0);
 
   const clickSettings = () => {
@@ -67,6 +68,7 @@ function Home(props) {
         <h2>WE USE COINBOT.</h2>
       </header> */}
       <SocketProvider>
+        {/* <p>{mobilePage}</p> */}
         <Menu clickSettings={clickSettings} theme={theme} />
         {/* <p>{JSON.stringify(props.store.accountReducer.userReducer)}</p> */}
 
@@ -74,14 +76,19 @@ function Home(props) {
           ? <Trade theme={theme} priceTicker={priceTicker} />
           : <NotActive theme={theme} />
         }
-        {(props.store.accountReducer.userReducer.approved)
-          ? <TradeList theme={theme} />
-          : <NotApproved theme={theme} />
+        {
+          props.store.accountReducer.userReducer.approved
+            ? width < 800 && mobilePage === 'newPair'
+              ? <TradeList theme={theme} />
+              : width > 800 && <TradeList theme={theme} />
+            : width < 800 && mobilePage === 'newPair'
+              ? <NotApproved theme={theme} />
+              : width > 800 && <NotApproved theme={theme} />
         }
         <Updates theme={theme} />
         <Status theme={theme} priceTicker={priceTicker} />
         <Settings showSettings={showSettings} clickSettings={clickSettings} theme={theme} priceTicker={priceTicker} />
-        {width < 800 && <MobileNav theme={theme} />}
+        {width < 800 && <MobileNav theme={theme} setMobilePage={setMobilePage} />}
       </SocketProvider>
     </div>
   );

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -72,20 +72,30 @@ function Home(props) {
         <Menu clickSettings={clickSettings} theme={theme} />
         {/* <p>{JSON.stringify(props.store.accountReducer.userReducer)}</p> */}
 
-        {(props.store.accountReducer.userReducer.active)
-          ? <Trade theme={theme} priceTicker={priceTicker} />
-          : <NotActive theme={theme} />
+        {
+          props.store.accountReducer.userReducer.active
+            ? width < 800 && mobilePage === 'newPair'
+              ? <Trade theme={theme} priceTicker={priceTicker} />
+              : width > 800 && <Trade theme={theme} priceTicker={priceTicker} />
+            : width < 800 && mobilePage === 'newPair'
+              ? <NotActive theme={theme} />
+              : width > 800 && <NotActive theme={theme} />
         }
+
         {
           props.store.accountReducer.userReducer.approved
-            ? width < 800 && mobilePage === 'newPair'
+            ? width < 800 && mobilePage === 'tradeList'
               ? <TradeList theme={theme} />
               : width > 800 && <TradeList theme={theme} />
-            : width < 800 && mobilePage === 'newPair'
+            : width < 800 && mobilePage === 'tradeList'
               ? <NotApproved theme={theme} />
               : width > 800 && <NotApproved theme={theme} />
         }
-        <Updates theme={theme} />
+
+        {width < 800 && mobilePage === 'messages'
+              ? <Updates theme={theme} />
+              : width > 800 && <Updates theme={theme} />}
+        
         <Status theme={theme} priceTicker={priceTicker} />
         <Settings showSettings={showSettings} clickSettings={clickSettings} theme={theme} priceTicker={priceTicker} />
         {width < 800 && <MobileNav theme={theme} setMobilePage={setMobilePage} />}

--- a/src/components/Menu/Menu.css
+++ b/src/components/Menu/Menu.css
@@ -29,6 +29,15 @@
         /* display    : block; */
         display       : flex;
         flex-direction: row;
-        margin: auto 0 auto auto;
+        /* margin: auto auto auto 0; */
+        width: 100%;
+    }
+    .greeting {
+        margin: auto 1rem;
+        margin-right: auto;
+    }
+    .menu-buttons {
+        margin-left: auto;
+        margin-right: 0;
     }
 }

--- a/src/components/Messages/Messages.css
+++ b/src/components/Messages/Messages.css
@@ -26,11 +26,11 @@
 
 @media (max-width: 800px) {
   .Messages {
-    grid-row     : 6;
-    grid-column  : 2 / 4;
-    height       : fit-content;
-    margin-bottom: .4rem;
-    max-height   : 40rem;
+    grid-row     : 5;
+    grid-column  : 2 / 3;
+    height       : unset;
+    margin-bottom: unset;
+    /* max-height   : 40rem; */
   }
   
   .message-board {

--- a/src/components/MobileNav/MobileNav.css
+++ b/src/components/MobileNav/MobileNav.css
@@ -6,8 +6,9 @@
     /* grid-column         : 4; */
     /* grid-row            : 1/2; */
     /* display             : block; */
-    /* display             : flex; */
-    /* flex-direction      : row; */
+    display             : flex;
+    flex-direction      : row;
+    justify-content: center;
     /* width               : max-content; */
 }
 

--- a/src/components/MobileNav/MobileNav.css
+++ b/src/components/MobileNav/MobileNav.css
@@ -1,14 +1,14 @@
 .MobileNav {
-    position               : absolute;
-    bottom                 : 0;
-    left                   : 0;
-    right                  : 0;
-    /* grid-column         : 4; */
-    /* grid-row            : 1/2; */
+    /* position               : absolute; */
+    /* bottom                 : 0; */
+    /* left                   : 0; */
+    /* right                  : 0; */
+    grid-column            : 2/3;
+    grid-row               : 4;
     /* display             : block; */
-    display             : flex;
-    flex-direction      : row;
-    justify-content: center;
+    display                : flex;
+    flex-direction         : row;
+    justify-content        : center;
     /* width               : max-content; */
 }
 

--- a/src/components/MobileNav/MobileNav.css
+++ b/src/components/MobileNav/MobileNav.css
@@ -1,34 +1,38 @@
 .MobileNav {
-    /* grid-column      : 4; */
-    /* grid-row         : 1/2; */
-    /* display       : block; */
-    /* display       : flex; */
-    /* flex-direction: row; */
-    width            : max-content;
+    position               : absolute;
+    bottom                 : 0;
+    left                   : 0;
+    right                  : 0;
+    /* grid-column         : 4; */
+    /* grid-row            : 1/2; */
+    /* display             : block; */
+    /* display             : flex; */
+    /* flex-direction      : row; */
+    /* width               : max-content; */
 }
 
-.greeting {
+/* .greeting {
     margin: auto 1rem;
 }
 
 .MobileNav-buttons {
     margin: auto 1rem;
-}
+} */
 
-.toggle {
+/* .toggle {
     background-color: #b34053;
     width           : 10rem;
     height          : 10rem;
     font-size       : xx-large;
-}
+} */
 
-@media (max-width: 800px) {
-    .MobileNav {
-        /* grid-column   : 2; */
-        /* grid-row      : 2; */
-        /* display    : block; */
-        display       : flex;
-        flex-direction: row;
-        margin: auto 0 auto auto;
-    }
-}
+/* @media (max-width: 800px) { */
+/* .MobileNav { */
+/* grid-column   : 2; */
+/* grid-row      : 2; */
+/* display    : block; */
+/* display       : flex; */
+/* flex-direction: row; */
+/* margin        : auto 0 auto auto; */
+/* } */
+/* } */

--- a/src/components/MobileNav/MobileNav.css
+++ b/src/components/MobileNav/MobileNav.css
@@ -1,0 +1,34 @@
+.MobileNav {
+    /* grid-column      : 4; */
+    /* grid-row         : 1/2; */
+    /* display       : block; */
+    /* display       : flex; */
+    /* flex-direction: row; */
+    width            : max-content;
+}
+
+.greeting {
+    margin: auto 1rem;
+}
+
+.MobileNav-buttons {
+    margin: auto 1rem;
+}
+
+.toggle {
+    background-color: #b34053;
+    width           : 10rem;
+    height          : 10rem;
+    font-size       : xx-large;
+}
+
+@media (max-width: 800px) {
+    .MobileNav {
+        /* grid-column   : 2; */
+        /* grid-row      : 2; */
+        /* display    : block; */
+        display       : flex;
+        flex-direction: row;
+        margin: auto 0 auto auto;
+    }
+}

--- a/src/components/MobileNav/MobileNav.js
+++ b/src/components/MobileNav/MobileNav.js
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from 'react';
+import { connect, useDispatch } from 'react-redux';
+import useWindowDimensions from '../../hooks/useWindowDimensions';
+import mapStoreToProps from '../../redux/mapStoreToProps';
+import './MobileNav.css'
+
+function MobileNav(props) {
+  const dispatch = useDispatch();
+
+  const { height, width } = useWindowDimensions();
+
+
+
+  return (
+
+    <div className={`MobileNav dark ${props.store.accountReducer.userReducer.theme}`}>
+      <center>
+        <p className="greeting">Hello {width}!</p>
+      </center>
+      <div className="MobileNav-buttons">
+        <button className={`btn-blue btn-logout ${props.theme}`} onClick={() => { props.clickSettings() }}>Settings</button>
+        <button className={`btn-blue btn-logout ${props.theme}`} onClick={() => dispatch({ type: 'LOGOUT' })}>Log Out</button>
+      </div>
+    </div>
+
+  )
+}
+
+export default connect(mapStoreToProps)(MobileNav);

--- a/src/components/MobileNav/MobileNav.js
+++ b/src/components/MobileNav/MobileNav.js
@@ -14,12 +14,11 @@ function MobileNav(props) {
   return (
 
     <div className={`MobileNav dark ${props.store.accountReducer.userReducer.theme}`}>
-      <center>
         <div className="MobileNav-buttons">
-          <button className={`btn-blue btn-nav ${props.theme}`} onClick={() => { props.clickSettings() }}>Settings</button>
-          <button className={`btn-blue btn-nav ${props.theme}`} onClick={() => dispatch({ type: 'LOGOUT' })}>Log Out</button>
+          <button className={`btn-blue btn-nav ${props.theme}`} onClick={() => { props.setMobilePage('tradeList') }}>Trade List</button>
+          <button className={`btn-blue btn-nav ${props.theme}`} onClick={() => { props.setMobilePage('newPair') }}>New Pair</button>
+          <button className={`btn-blue btn-nav ${props.theme}`} onClick={() => { props.setMobilePage('messages') }}>Messages</button>
         </div>
-      </center>
     </div>
 
   )

--- a/src/components/MobileNav/MobileNav.js
+++ b/src/components/MobileNav/MobileNav.js
@@ -15,12 +15,11 @@ function MobileNav(props) {
 
     <div className={`MobileNav dark ${props.store.accountReducer.userReducer.theme}`}>
       <center>
-        <p className="greeting">Hello {width}!</p>
+        <div className="MobileNav-buttons">
+          <button className={`btn-blue btn-nav ${props.theme}`} onClick={() => { props.clickSettings() }}>Settings</button>
+          <button className={`btn-blue btn-nav ${props.theme}`} onClick={() => dispatch({ type: 'LOGOUT' })}>Log Out</button>
+        </div>
       </center>
-      <div className="MobileNav-buttons">
-        <button className={`btn-blue btn-logout ${props.theme}`} onClick={() => { props.clickSettings() }}>Settings</button>
-        <button className={`btn-blue btn-logout ${props.theme}`} onClick={() => dispatch({ type: 'LOGOUT' })}>Log Out</button>
-      </div>
     </div>
 
   )

--- a/src/components/Status/Status.css
+++ b/src/components/Status/Status.css
@@ -1,5 +1,5 @@
 .Status {
-    grid-column     : 1/4;
+    grid-column     : 2/4;
     grid-row        : 1;
     /* display: block; */
 }
@@ -12,7 +12,7 @@
 
 @media (max-width: 800px) {
     .Status {
-        grid-column: 1/3;
+        grid-column: 2/3;
         grid-row: 3;
         /* display: block; */
     }

--- a/src/components/Trade/Trade.css
+++ b/src/components/Trade/Trade.css
@@ -11,6 +11,7 @@
     display    : block;
     grid-column: 2;
     grid-row   : 5;
+    /* max-height: 50vh; */
   }
 
 }

--- a/src/components/TradeList/TradeList.css
+++ b/src/components/TradeList/TradeList.css
@@ -6,11 +6,13 @@
 }
 @media (max-width: 800px) {
     .TradeList {
-        grid-row     : 4;
-        grid-column  : 2 / 3;
+        grid-row     : 5;
+        grid-column  : 2;
+        margin-bottom: .4rem;
         /* overflow-y: auto; */
-        display      : block;
-        max-height: 80vh;
+        /* display      : block; */
+        /* max-height: 50vh; */
+        /* max-height: unset; */
     }
 
 }

--- a/src/hooks/useWindowDimensions.js
+++ b/src/hooks/useWindowDimensions.js
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import ReactDOM from "react-dom";
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height
+  };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowDimensions;
+}

--- a/src/hooks/useWindowDimensions.js
+++ b/src/hooks/useWindowDimensions.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 
+// https://stackoverflow.com/questions/36862334/get-viewport-window-height-in-reactjs
+
 function getWindowDimensions() {
   const { innerWidth: width, innerHeight: height } = window;
   return {


### PR DESCRIPTION
Add a nav bar that shows up on mobile to navigate between viewing all trades, starting new trades, and messages. There's a lot that could be improved but it's better than the old way which required special scrolling techniques to get past the trade list.

One large issue with this is that messages disappear if navigated away from the component because it stops rendering and they are not saved.