### PR TITLE
fix Time

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS "orders"
   product_id character varying COLLATE pg_catalog."default",
   time_in_force character varying COLLATE pg_catalog."default",
   created_at timestamptz,
+  flipped_at timestamptz,
   done_at timestamptz,
   done_reason character varying COLLATE pg_catalog."default",
   fill_fees numeric(32,16),

--- a/server/modules/databaseClient.js
+++ b/server/modules/databaseClient.js
@@ -18,8 +18,8 @@ const storeTrade = (newOrder, originalDetails, flipped_at) => {
       newOrder.settled,
       newOrder.product_id,
       newOrder.time_in_force,
-      flipped_at,
       newOrder.created_at,
+      flipped_at,
       newOrder.done_at,
       newOrder.fill_fees,
       // bring the fees from the previous order to the new one for more accurate profit calculation

--- a/server/modules/databaseClient.js
+++ b/server/modules/databaseClient.js
@@ -1,6 +1,7 @@
 const pool = require('./pool');
 
 // stores the details of a trade-pair. The originalDetails are details that stay with a trade-pair when it is flipped
+// flipped_at is the "Time" shown on the interface. It has no other function
 const storeTrade = (newOrder, originalDetails, flipped_at) => {
   return new Promise((resolve, reject) => {
     // add new order to the database

--- a/server/modules/databaseClient.js
+++ b/server/modules/databaseClient.js
@@ -1,13 +1,13 @@
 const pool = require('./pool');
 
 // stores the details of a trade-pair. The originalDetails are details that stay with a trade-pair when it is flipped
-const storeTrade = (newOrder, originalDetails) => {
+const storeTrade = (newOrder, originalDetails, flipped_at) => {
   return new Promise((resolve, reject) => {
     // add new order to the database
     const sqlText = `INSERT INTO "orders" 
       ("id", "userID", "price", "size", "trade_pair_ratio", "side", "settled", "product_id", "time_in_force", 
-      "created_at", "done_at", "fill_fees", "previous_fill_fees", "filled_size", "executed_value", "original_buy_price", "original_sell_price") 
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17);`;
+      "created_at", "flipped_at", "done_at", "fill_fees", "previous_fill_fees", "filled_size", "executed_value", "original_buy_price", "original_sell_price") 
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18);`;
     pool.query(sqlText, [
       newOrder.id,
       originalDetails.userID,
@@ -18,6 +18,7 @@ const storeTrade = (newOrder, originalDetails) => {
       newOrder.settled,
       newOrder.product_id,
       newOrder.time_in_force,
+      flipped_at,
       newOrder.created_at,
       newOrder.done_at,
       newOrder.fill_fees,

--- a/server/routes/account.router.js
+++ b/server/routes/account.router.js
@@ -372,6 +372,7 @@ router.post('/ordersReset', rejectUnauthenticated, async (req, res) => {
       product_id character varying COLLATE pg_catalog."default",
       time_in_force character varying COLLATE pg_catalog."default",
       created_at timestamptz,
+      flipped_at timestamptz,
       done_at timestamptz,
       done_reason character varying COLLATE pg_catalog."default",
       fill_fees numeric(32,16),
@@ -438,6 +439,7 @@ router.post('/factoryReset', rejectUnauthenticated, async (req, res) => {
     CREATE TABLE IF NOT EXISTS "bot_settings"
     (
       "loop_speed" integer DEFAULT 1,
+      "orders_to_sync" integer DEFAULT 100,
       "full_sync" integer DEFAULT 10,
       "maintenance" boolean DEFAULT false
     );
@@ -463,6 +465,7 @@ router.post('/factoryReset', rejectUnauthenticated, async (req, res) => {
       product_id character varying COLLATE pg_catalog."default",
       time_in_force character varying COLLATE pg_catalog."default",
       created_at timestamptz,
+      flipped_at timestamptz,
       done_at timestamptz,
       done_reason character varying COLLATE pg_catalog."default",
       fill_fees numeric(32,16),

--- a/server/routes/trade.router.js
+++ b/server/routes/trade.router.js
@@ -40,7 +40,7 @@ router.post('/', rejectUnauthenticated, async (req, res) => {
       // even after returning the details. robot.syncOrders will think it settled if it sees it in the db first
       await robot.sleep(100);
       // store the new trade in the db. the trade details are also sent to store trade position prices
-      await databaseClient.storeTrade(pendingTrade, tradeDetails);
+      await databaseClient.storeTrade(pendingTrade, tradeDetails, pendingTrade.created_at);
 
       await robot.updateFunds(userID);
 

--- a/server/routes/trade.router.js
+++ b/server/routes/trade.router.js
@@ -40,6 +40,7 @@ router.post('/', rejectUnauthenticated, async (req, res) => {
       // even after returning the details. robot.syncOrders will think it settled if it sees it in the db first
       await robot.sleep(100);
       // store the new trade in the db. the trade details are also sent to store trade position prices
+      // storing the created_at value in the flipped_at field will fix issues where the time would change when resyncing
       await databaseClient.storeTrade(pendingTrade, tradeDetails, pendingTrade.created_at);
 
       await robot.updateFunds(userID);

--- a/src/components/SingleTrade/SingleTrade.js
+++ b/src/components/SingleTrade/SingleTrade.js
@@ -96,8 +96,15 @@ function SingleTrade(props) {
           } ~<strong>Size </strong>{Number(props.order.size).toFixed(8)} ~
           <strong>Value</strong> ${numberWithCommas((Math.round((props.order.price * props.order.size) * 100) / 100).toFixed(2))} ~
           <strong>Net Profit</strong> ${profit.toFixed(8)}
-          <strong> ~Time</strong> {new Date(props.order.created_at).toLocaleString('en-US')}
+          {/* <strong> ~Time</strong> {new Date(props.order.created_at).toLocaleString('en-US')} */}
+          <strong> ~Time </strong> {props.order.flipped_at 
+          ? new Date(props.order.flipped_at).toLocaleString('en-US')
+          : new Date(props.order.created_at).toLocaleString('en-US')}
           <br />
+          {/* created: {JSON.stringify(props.order.created_at)} 
+          <br />
+          flipped: {JSON.stringify(props.order.flipped_at)}
+          <br /> */}
           {
             showAll && !deleting && <><strong> Percent Increase:</strong> {Number(props.order.trade_pair_ratio)}</>
           }


### PR DESCRIPTION
Fixes an issue where the Time value on the interface would change to the current time when reordered. This made it look like orders had recently settled that had actually not been changed in potentially a long time.

This update is backwards compatible, so the error will still occur for trades that were placed before the update until they are flipped. Flipping them will fix the issue.