### PR TITLE
Clean up

### DIFF
--- a/src/components/Settings/Admin/Admin.js
+++ b/src/components/Settings/Admin/Admin.js
@@ -124,10 +124,10 @@ function Admin(props) {
       {/* SET LOOP SPEED */}
 
       <h4>Set Loop Speed</h4>
-      <p>
+      {props.tips && <p>
         This will adjust the speed of the loop. You may want to slow it down to use fewer resources and handle more users.
         Higher numbers are slower. 1 is the fastest, and the speed is a multiplier. So 4 is 4x slower than 1 for example.
-      </p>
+      </p>}
       <p>Current loop speed: {props.store.settingsReducer.allSettingsReducer.loop_speed}</p>
       <label htmlFor="loopSpeed">
         Set speed:
@@ -151,10 +151,10 @@ function Admin(props) {
       {/* SET FULL SYNC FREQUENCY */}
 
       <h4>Set Full Sync Frequency</h4>
-      <p>
+      {props.tips && <p>
         This will adjust how often the bot does a full sync. A full sync takes longer and is more CPU intensive,
         but will check for and delete extra trades etc. A quick sync only checks for recently settled trades.
-      </p>
+      </p>}
       <p>Current frequency: Every {props.store.settingsReducer.allSettingsReducer.full_sync} loop{props.store.settingsReducer.allSettingsReducer.full_sync > 1 && 's'}</p>
       <label htmlFor="fullSync">
         Set frequency:
@@ -179,11 +179,11 @@ function Admin(props) {
 
       <h4>Set Synced Order Quantity</h4>
       {/* {JSON.stringify(props.store.settingsReducer.allSettingsReducer)} */}
-      <p>
+      {props.tips && <p>
         This adjusts how many trades per side to keep in sync with Coinbase Pro (How many buys, how many sells). There is a max of 200, which 
         keeps the total under the 500 order limit on Coinbase pro, while also allowing a margin for flipping trades. Putting a low number here
         may slightly increase the speed of the bot or lower CPU usage, but risks that all trades on one side will settle before the bot has the chance to sync more.
-      </p>
+      </p>}
       <p>Current quantity: {props.store.settingsReducer.allSettingsReducer.orders_to_sync}</p>
       <label htmlFor="fullSync">
         Set Sync Quantity:
@@ -208,9 +208,9 @@ function Admin(props) {
 
       <h4>Toggle Maintenance Mode</h4>
       {/* {JSON.stringify(props.store.settingsReducer.allSettingsReducer.maintenance)} */}
-      <p>
+      {props.tips && <p>
         This essentially pauses all user loops. Can be useful when migrating the bot to another server for example.
-      </p>
+      </p>}
       {props.store.settingsReducer.allSettingsReducer.maintenance
         ?
         <p>Maintenance mode is currently ON</p>
@@ -234,11 +234,11 @@ function Admin(props) {
               ignore={() => setFactoryResetting(false)}
             />}
           <h4>Factory Reset</h4>
-          <p>
+          {props.tips && <p>
             This will delete everything! Use with caution!
             Do not depend on being able to press this button after a git pull as a way to reset the database.
             You may not be able to log back in after the pull.
-          </p>
+          </p>}
           <p>
             CAUTION <button
               className="btn-logout btn-red"
@@ -254,9 +254,9 @@ function Admin(props) {
                 // if cancel, toggle boolean so message goes away
                 ignore={() => setResettingOrders(false)}
               />}
-          <p>
+          {props.tips && <p>
             This button will only reset the orders table. This will clear the orders for ALL USERS! If you mean to just clear your own, do that in the "Reset" tab
-          </p>
+          </p>}
           <p>
             CAUTION <button
               className="btn-logout btn-red"

--- a/src/components/Settings/AutoSetup/AutoSetup.js
+++ b/src/components/Settings/AutoSetup/AutoSetup.js
@@ -140,17 +140,18 @@ function AutoSetup(props) {
     <div className="AutoSetup settings-panel scrollable">
       <div className="divider" />
       <h4>Auto Setup</h4>
-      {/* <p>{props.priceTicker} avail {availableFundsUSD}</p> */}
-      <p>
-        Enter the parameters you want and the bot will keep placing trades for you based on
-        those parameters until you run out of cash, or until you have 10,000 trade-pairs.
-        This is much easier than manually placing dozens of trades if they are following a basic pattern.
-      </p>
-      <p>
-        Please be aware that the bot will slow down slightly with every 999 trades.
-      </p>
+      {props.tips && <>
+        <p>
+          Enter the parameters you want and the bot will keep placing trades for you based on
+          those parameters until you run out of cash, or until you have 10,000 trade-pairs.
+          This is much easier than manually placing dozens of trades if they are following a basic pattern.
+        </p>
+        <p>
+          Please be aware that the bot will slow down slightly with every 999 trades.
+        </p>
 
-      <div className="divider" />
+        <div className="divider" />
+      </>}
       <div className='auto-setup-form-and-results'>
 
         <form className='auto-setup-form' onSubmit={submitAutoSetup}>
@@ -233,20 +234,20 @@ function AutoSetup(props) {
           <p>
             <strong>{numberWithCommas(setupResults.toFixed(2))}</strong>
           </p>
-          <p>
+          {props.tips && <p>
             This calculation isn't perfect but it will get close. It can also change if the price of BTC moves up or down significantly while the
             trades are being set up.
-          </p>
+          </p>}
           <p>
-            Approximate number of trades the setup process will create:
+            Approximate number of trades to create:
           </p>
           <p>
             <strong>{numberWithCommas(totalTrades)}</strong>
           </p>
-          <p>
+          {props.tips && <p>
             However, there is a total limit of 10,000 trades placed per user. Latency may cause it to
             create more, in which case you got lucky.
-          </p>
+          </p>}
 
         </div>
       </div>

--- a/src/components/Settings/BulkDelete/BulkDelete.js
+++ b/src/components/Settings/BulkDelete/BulkDelete.js
@@ -36,17 +36,19 @@ function BulkDelete(props) {
       {/* SYNC ALL TRADES */}
       <div className="divider" />
       <h4>Synchronize All Trades</h4>
-      <p>
+      {props.tips && <p>
         This will delete all open orders from coinbase and replace them based on the trades stored in the
-        database. It can sometimes fix issues that cause repeated errors, and may take a few minutes to complete
-      </p>
+        database. It can sometimes fix issues that cause repeated errors, and may take a few minutes to complete.
+      </p>}
       <button className={`btn-blue medium ${props.theme}`} onClick={() => dispatch({ type: 'SYNC_ORDERS' })}>Sync All Trades</button>
 
       {/* DELETE RANGE */}
       <div className="divider" />
       <h4>Delete Range</h4>
-      <p>Delete all trades that fall within a price range, inclusive of the numbers set. This is based on the current price,
-        so if the trade is a buy, it will look at the buy price. If it is a sell, it will look at the sell price.</p>
+      {props.tips && <p>
+        Delete all trades that fall within a price range, inclusive of the numbers set. This is based on the current price,
+        so if the trade is a buy, it will look at the buy price. If it is a sell, it will look at the sell price.
+      </p>}
 
       <label htmlFor="upper_limit">
         Upper Limit:

--- a/src/components/Settings/General/General.js
+++ b/src/components/Settings/General/General.js
@@ -64,9 +64,9 @@ function General(props) {
       {/* KILL PREVENTION */}
 
       <h4>Kill Prevention</h4>
-      <p>
+      {props.tips && <p>
         Removes the kill button from the trade pairs. This helps prevent accidental deletion of trades. Highly recommended to leave this on.
-      </p>
+      </p>}
       {props.store.accountReducer.userReducer.kill_locked
         ? <button className={`btn-blue medium ${props.theme}`} onClick={() => { killLock() }}>Unlock</button>
         : <button className={`btn-blue medium ${props.theme}`} onClick={() => { killLock() }}>Lock</button>
@@ -75,10 +75,10 @@ function General(props) {
 
       {/* PAUSE */}
       <h4>Pause</h4>
-      <p>
+      {props.tips && <p>
         Pauses the bot. Trades will stay in place, but the bot will not check on them or flip them. If they are cancelled on Coinbase, the bot will not notice until it is unpaused.
         Be careful not to trade funds away manually while the bot is paused, or there might be an insufficient funds error.
-      </p>
+      </p>}
       {props.store.accountReducer.userReducer.paused
         ? <button className={`btn-blue medium ${props.theme}`} onClick={() => { pause() }}>Unpause</button>
         : <button className={`btn-blue medium ${props.theme}`} onClick={() => { pause() }}>Pause</button>
@@ -87,7 +87,7 @@ function General(props) {
 
       {/* MAX TRADES ON SCREEN */}
       <h4>Max Trades on Screen</h4>
-      <p>
+      {props.tips && <p>
         Limit the number of trades to load per side (buy/sell). This can make load times shorter and limit the amount of scrolling
         needed to get to the split.
         <br />
@@ -96,7 +96,7 @@ function General(props) {
         <br />
         <br />
         There is a hard limit of 10,000 open trades per user, so there is no reason to set the value higher than that.
-      </p>
+      </p>}
       <p>Current max trades to load per side: {Number(props.store.accountReducer.userReducer.max_trade_load)}</p>
       <label htmlFor="reinvest_ratio">
         Set Max:
@@ -114,9 +114,9 @@ function General(props) {
 
       {/* PROFIT ACCURACY */}
       <h4>Profit accuracy</h4>
-      <p>
+      {props.tips && <p>
         How many decimals to display on screen for profits.
-      </p>
+      </p>}
       <p>Current accuracy: {Number(props.store.accountReducer.userReducer.profit_accuracy)}</p>
       <label htmlFor="profit_accuracy">
         Set Max:

--- a/src/components/Settings/History/History.js
+++ b/src/components/Settings/History/History.js
@@ -38,7 +38,7 @@ function History(props) {
       <div className="divider" />
       <h4>Export .xlsx spreadsheet</h4>
       <p>
-        Export and download your entire trade history as an xlsx spreadsheet. I'm adding extra words here instead of doing proper CSS.
+        Export and download your entire trade history as an xlsx spreadsheet.
       </p>
       <button className={`btn-red medium ${props.theme}`} onClick={() => { exportXlxs() }}>Export</button>
       <div className="divider" />

--- a/src/components/Settings/Investment/Investment.js
+++ b/src/components/Settings/Investment/Investment.js
@@ -102,9 +102,9 @@ function Investment(props) {
 
       {/* REINVEST */}
       <h4>Reinvestment</h4>
-      <p>Coinbot can try to reinvest your profits for you. Be aware that this may not
+      {props.tips && <p>Coinbot can try to reinvest your profits for you. Be aware that this may not
         work if the profit is too small.
-      </p>
+      </p>}
       {(props.store.accountReducer.userReducer.reinvest)
         ? <button className={`btn-blue medium ${props.theme}`} onClick={() => { reinvest() }}>Turn off</button>
         : <button className={`btn-blue medium ${props.theme}`} onClick={() => { reinvest() }}>Turn on</button>
@@ -112,8 +112,9 @@ function Investment(props) {
       {props.store.accountReducer.userReducer.reinvest &&
         <>
           {((reinvest_ratio > 100) || (props.store.accountReducer.userReducer.reinvest_ratio > 100)) &&
-            <p>** WARNING! ** <br /> Setting the reinvestment ratio higher than 100% will take money from your available funds!
-              You will need to keep an eye on the bot and make sure you don't run out!</p>
+            <><p>** WARNING! ** </p>
+            {props.tips && <p> Setting the reinvestment ratio higher than 100% will take money from your available funds!
+              You will need to keep an eye on the bot and make sure you don't run out!</p>}</>
           }
           <p>Current reinvestment ratio: {props.store.accountReducer.userReducer.reinvest_ratio}%</p>
           <label htmlFor="reinvest_ratio">
@@ -137,10 +138,10 @@ function Investment(props) {
 
       {/* RESERVE */}
       <h4>Reserve</h4>
-      <p>
+      {props.tips && <p>
         Automatically turn off reinvestment when the available funds fall below a set amount.
         This will not be automatically turned back on for you.
-      </p>
+      </p>}
       <>
         <p>Current reserve: {props.store.accountReducer.userReducer.reserve}</p>
         <label htmlFor="reserve">
@@ -168,11 +169,11 @@ function Investment(props) {
         props.store.accountReducer.userReducer.reinvest &&
         <>
           <h4>Max Trade Size</h4>
-          <p>
+          {props.tips && <p>
             Coinbot can try to limit the size of your trades. This is useful in case you want to
             stop reinvesting after a certain point, but keep reinvestment turned on for all other trades.
             Size cap is in USD. If set to 0, the bot will ignore it and default to the reinvestment ratio.
-          </p>
+          </p>}
           {(props.store.accountReducer.userReducer.max_trade)
             ? <button className={`btn-blue medium ${props.theme}`} onClick={() => { tradeMax() }}>Turn off</button>
             : <button className={`btn-blue medium ${props.theme}`} onClick={() => { tradeMax() }}>Turn on</button>
@@ -195,12 +196,11 @@ function Investment(props) {
               <br />
               <button className={`btn-blue btn-reinvest medium ${props.theme}`} onClick={(event) => { storeMaxTradeSize(event) }}>Save Max</button>
               <>
-                <p>How much of the profits should the bot reinvest after the max is hit?
+                {props.tips && <p>How much of the profits should the bot reinvest after the max is hit?
                   Leave this at 0 to stop reinvestment after the max. If set above 0, there is no limit to how large the
-                  size will get. Probably a good idea to stay under 100%</p>
+                  size will get. Probably a good idea to stay under 100%</p>}
                 {((postMaxReinvestRatio > 100) || (props.store.accountReducer.userReducer.reinvest_ratio > 100)) &&
-                  <p>** WARNING! ** <br /> Setting the reinvestment ratio higher than 100% will take money from your available funds!
-                    You will need to keep an eye on the bot and make sure you don't run out!</p>
+                  <p>** WARNING! ** <br /> Setting the reinvestment ratio higher than 100% will take money from your available funds!</p>
                 }
                 <p>Current post-max reinvestment ratio: {props.store.accountReducer.userReducer.post_max_reinvest_ratio}%</p>
                 <label htmlFor="postMaxReinvestRatio">
@@ -227,9 +227,9 @@ function Investment(props) {
 
       {/* BULK PERCENTAGE CHANGE */}
       <h4>Bulk Percentage Change</h4>
-      <p>
-        EXPERIMENTAL FEATURE. This will change the trade pair ratio for ALL trades to a uniform percentage. This can be useful for when your fees change due to trade volume and you want to change the ratio accordingly.
-      </p>
+      {props.tips && <p>
+        This will change the trade pair ratio for ALL trades to a uniform percentage. This can be useful for when your fees change due to trade volume and you want to change the ratio accordingly.
+      </p>}
       <>
         <label htmlFor="bulk_pair_ratio">
           New Ratio:

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -38,3 +38,7 @@
 .settings-panel {
   max-height: 65vh;
 }
+
+.tips {
+float: right;
+}

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -7,7 +7,7 @@
   background-color: #acacaf;
   z-index         : 1;
   height          : fit-content;
-  width           : fit-content;
+  width           : 100%;
   max-width       : 50rem;
   margin          : 0 auto;
   padding         : 1rem;
@@ -23,6 +23,7 @@
     display    : block;
     grid-column: 2;
     grid-row   : 2/6;
+    width: fit-content;
     /* height  : unset; */
   }
 

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -15,22 +15,40 @@ import BulkDelete from './BulkDelete/BulkDelete';
 
 function Settings(props) {
   const [settingsPage, setSettingsPage] = useState('general');
+  const [tips, setTips] = useState(false);
+
+
 
   if (props.showSettings) {
     return (
       <div className={`Settings ${props.theme}`}>
         <button className={`btn-logout btn-red ${props.store.accountReducer.userReducer.theme}`} onClick={() => { props.clickSettings() }}>X</button>
+
+        <p className="info tips">
+          <strong>Show Tips</strong>
+          {/* <br /> */}
+          <input
+            type="checkbox"
+            id="topping"
+            name="topping"
+            value="Paneer"
+            checked={tips}
+            onChange={() => setTips(!tips)}
+          />
+        </p>
+
         <h2 className="settings-header">Settings</h2>
+
         <SettingsNav setSettingsPage={setSettingsPage} settingsPage={settingsPage} />
         {
           {
-            'general': <General theme={props.theme} />,
-            'investment': <Investment theme={props.theme} />,
-            'history': <History theme={props.theme} />,
-            'autoSetup': <AutoSetup theme={props.theme} priceTicker={props.priceTicker} />,
-            'reset': <Reset theme={props.theme} />,
-            'bulkDelete': <BulkDelete theme={props.theme} />,
-            'admin': <Admin theme={props.theme} />
+            'general': <General theme={props.theme} tips={tips} />,
+            'investment': <Investment theme={props.theme} tips={tips} />,
+            'autoSetup': <AutoSetup theme={props.theme} tips={tips} priceTicker={props.priceTicker} />,
+            'bulkDelete': <BulkDelete theme={props.theme} tips={tips} />,
+            'history': <History theme={props.theme} tips={tips} />,
+            'reset': <Reset theme={props.theme} tips={tips} />,
+            'admin': <Admin theme={props.theme} tips={tips} />
           }[settingsPage]
         }
       </div>


### PR DESCRIPTION
Add a Show Tips checkbox that is off by default, and shows all the explanations of settings when turned on. This clears up a lot of clutter for users who already know what they are doing.