### PR TITLE
Fix chat

### DIFF
--- a/client/src/components/Messages/MessageSection.tsx
+++ b/client/src/components/Messages/MessageSection.tsx
@@ -62,7 +62,7 @@ export function MessageSection({
     }
   }, [messages, initialRender, mobileCollapsed, header]);
 
-  console.log(messages, 'messages ' + header);
+  // console.log(messages, 'messages ' + header);
 
 
   return (

--- a/server/modules/cache.js
+++ b/server/modules/cache.js
@@ -271,9 +271,9 @@ class Messenger {
 
 
     // check and limit the number of stored messages
-    if (this.messages.length > 1000) {
-      this.messages.length = 1000;
-    }
+    // if (this.messages.length > 1000) {
+    //   this.messages.length = 1000;
+    // }
     // tell user to update messages
     const jsonMsg = JSON.stringify(message);
     console.log(jsonMsg, 'jsonMsg');
@@ -293,9 +293,9 @@ class Messenger {
     this.messageCount++;
     this.chatMessageCount++;
     // check and limit the number of stored messages
-    if (this.messages.length > 1000) {
-      this.messages.length = 1000;
-    }
+    // if (this.messages.length > 1000) {
+    //   this.messages.length = 1000;
+    // }
     // tell user to update messages
     const jsonMsg = JSON.stringify(message);
     this.sockets.forEach(socket => {

--- a/server/modules/cache.js
+++ b/server/modules/cache.js
@@ -1,6 +1,6 @@
 import { devLog } from "./utilities.js";
 import { Coinbase } from "./coinbaseClient.js";
-import { getAllErrorMessages, getAllMessages, saveMessage } from "./database/messages.js";
+import { getAllErrorMessages, getAllMessages, getBotMessages, getChatMessages, saveMessage } from "./database/messages.js";
 import { databaseClient } from "./databaseClient.js";
 
 const botSettings = new class BotSettings {
@@ -191,6 +191,7 @@ class Messenger {
     this.errors = new Array();
     this.messages = new Array();
     this.messageCount = Number(1);
+    this.chatMessages = new Array();
     this.chatMessageCount = Number(1);
     this.errorCount = Number(1);
   }
@@ -226,10 +227,15 @@ class Messenger {
   async saturateMessages() {
     // get the messages from the database
     const messages = await getAllMessages(this.userID);
+    const botMessages = await getBotMessages(this.userID);
+    const chatMessages = await getChatMessages(this.userID);
+    console.log(messages, 'all messages from database', this.userID);
     // console.log(messages, 'all messages from database', this.userID);
     // clear the messages array and add the messages from the database
     this.messages.length = 0;
-    this.messages.push(...messages);
+    this.messages.push(...botMessages);
+    this.chatMessages.length = 0;
+    this.chatMessages.push(...chatMessages);
     // set the message count to the length of the messages array
     this.messageCount = this.messages.length;
     // set the chat message count to the length of the chat messages array
@@ -258,22 +264,24 @@ class Messenger {
     if (message.text) {
       const saved = await saveMessage(this.userID, newMessage);
       // console.log(saved, 'saved and returned from saveMessage');
-      this.messages.unshift(saved);
+      if (message.type === 'chat') {
+        this.chatMessages.unshift(saved);
+        this.chatMessageCount++;
+        // check and limit the number of stored messages
+        if (this.chatMessages.length > 1000) {
+          this.chatMessages.length = 1000;
+        }
+      } else {
+        this.messages.unshift(saved);
+        this.messageCount++;
+        // check and limit the number of stored messages
+        if (this.messages.length > 1000) {
+          this.messages.length = 1000;
+        }
+      }
       fullMessage = saved;
       // save the message to the database
     }
-    // increase the counts
-    this.messageCount++;
-    if (message.type === 'chat') {
-      // only increase chat count if it is a chat type message
-      this.chatMessageCount++;
-    }
-
-
-    // check and limit the number of stored messages
-    // if (this.messages.length > 1000) {
-    //   this.messages.length = 1000;
-    // }
     // tell user to update messages
     const jsonMsg = JSON.stringify(message);
     console.log(jsonMsg, 'jsonMsg');
@@ -286,16 +294,15 @@ class Messenger {
     // message will already be formatted as a message object
     // add message to messages array if there is text to store
     if (message.text) {
-      this.messages.unshift(message);
+      this.chatMessages.unshift(message);
       // message is already in the database
     }
     // increase the counts
-    this.messageCount++;
     this.chatMessageCount++;
     // check and limit the number of stored messages
-    // if (this.messages.length > 1000) {
-    //   this.messages.length = 1000;
-    // }
+    if (this.chatMessages.length > 1000) {
+      this.chatMessages.length = 1000;
+    }
     // tell user to update messages
     const jsonMsg = JSON.stringify(message);
     this.sockets.forEach(socket => {
@@ -319,7 +326,7 @@ class Messenger {
     // const messages = structuredClone(this.messages);
     // extract the chats
 
-    this.messages.forEach(message => {
+    this.chatMessages.forEach(message => {
       // console.log(message, 'message');
       if (message.type === 'chat') {
         chats.push(message);

--- a/server/modules/coinbaseClient.js
+++ b/server/modules/coinbaseClient.js
@@ -234,6 +234,7 @@ class Coinbase {
   async getFills(params) {
     return new Promise(async (resolve, reject) => {
       try {
+        await sleep(100);
         // data should just be blank
         const data = null;
         const API = {

--- a/server/modules/database/messages.js
+++ b/server/modules/database/messages.js
@@ -47,6 +47,23 @@ export async function getAllMessages(userID) {
   })
 }
 
+// get only the bot messages
+export async function getBotMessages(userID) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const sqlText = `
+      SELECT * 
+      FROM "messages" 
+      WHERE ("user_id" = $1 OR ("to" = $2 OR "to" = 'all')) AND "type" != 'error' AND "type" != 'chat'
+      ORDER BY "timestamp" DESC LIMIT 1000;`;
+      const result = await pool.query(sqlText, [userID, userID.toString()]);
+      resolve(result.rows);
+    } catch (err) {
+      reject(err);
+    }
+  })
+}
+
 export async function getAllErrorMessages(userID) {
   return new Promise(async (resolve, reject) => {
     try {

--- a/server/modules/database/messages.js
+++ b/server/modules/database/messages.js
@@ -113,3 +113,17 @@ export async function deleteMessage(userID, messageID) {
     }
   })
 }
+
+export async function deletePrevious30DaysMessages() {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const sqlText = `
+        DELETE FROM "messages"
+        WHERE "type" != 'chat' AND "timestamp" < NOW() - INTERVAL '30 days';`;
+      const result = await pool.query(sqlText);
+      resolve(result);
+    } catch (err) {
+      reject(err);
+    }
+  })
+}

--- a/server/modules/robot.js
+++ b/server/modules/robot.js
@@ -102,7 +102,7 @@ async function syncOrders(userID) {
   // get the user settings from cache;
 
   // keep track of how long the loop takes. Helps prevent rate limiting
-  const t0 = performance.now();
+  const startTime = performance.now();
 
   try {
     const loopNumber = userStorage[userID].getLoopNumber();
@@ -152,10 +152,11 @@ async function syncOrders(userID) {
   } finally {
     // when everything is done, call the sync again if the user still exists
     if (user) {
-      const t1 = performance.now();
+      const endTime = performance.now();
       // API is limited to 10/sec, so make sure the bot waits that long between loops
-      if (100 - (t1 - t0) > 0) {
-        await sleep(100 - (t1 - t0));
+      if (100 - (endTime - startTime) > 0) {
+        // adding an extra 200ms because the bot was still getting rate limited
+        await sleep(300 - (endTime - startTime));
       }
       // wait however long the admin requires, then start new loop
       setTimeout(() => {
@@ -632,7 +633,7 @@ async function updateMultipleOrders(userID, params) {
     // loop over the array and update each trade
     for (let i = 0; i < ordersArray.length; i++) {
       // keep track of how long each loop takes. Helps prevent rate limiting
-      const t0 = performance.now();
+      const startTime = performance.now();
       messenger[userID].newMessage({
         type: 'general',
         text: `Syncing ${i + 1} of ${ordersArray.length} orders that need to be synced`
@@ -670,10 +671,10 @@ async function updateMultipleOrders(userID, params) {
           errorText: errorText
         })
       } // end catch
-      const t1 = performance.now();
+      const endTime = performance.now();
       // API is limited to 10/sec, so make sure the bot waits that long between loops
-      if (100 - (t1 - t0) > 0) {
-        await sleep(100 - (t1 - t0));
+      if (100 - (endTime - startTime) > 0) {
+        await sleep(100 - (endTime - startTime));
       }
     } // end for loop
     // delete orders to check since they have now been checked

--- a/server/routes/account.router.js
+++ b/server/routes/account.router.js
@@ -468,6 +468,13 @@ router.get('/messages', rejectUnauthenticated, async (req, res) => {
     const userMessages = {}
     userMessages.botMessages = messenger[userID].getMessages();
     userMessages.chatMessages = messenger[userID].getChatMessages();
+    if (userMessages.chatMessages.length > 1000) {
+      userMessages.chatMessages.length = 1000;
+    }
+    if (userMessages.botMessages.length > 1000) {
+      userMessages.botMessages.length = 1000;
+    }
+    console.log(userMessages.chatMessages.length, '< userMessages');
     res.send(userMessages);
   } catch (err) {
     devLog(err, 'problem in get messages route');


### PR DESCRIPTION
Fix a bug where all previous chats would disappear when any user sends a new message. This happened because the cache would trim itself down to 1000 messages at every message, but it would do this for bot messages and chat messages combined. There were a lot of bot messages, so it would fill that limit quickly and chats would disappear.

Current fix is to separate the bot and chat messages in the cache, and limit them individually to 1000. This works but the whole thing really needs to be reworked from the ground up as it's just a big pile of feature creep with zero plan from the start. Another day.